### PR TITLE
Fixed requirements for M2 mac, and sb3 examples

### DIFF
--- a/examples/sb3_examples.ipynb
+++ b/examples/sb3_examples.ipynb
@@ -11,6 +11,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pip install stable-baselines3"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [
@@ -33,7 +46,8 @@
     "import sys\n",
     "sys.path.insert(0, '..')\n",
     "from stable_baselines3.common.env_checker import check_env\n",
-    "from citylearn.citylearn import CityLearnEnv, StableBaselines3Wrapper\n",
+    "from citylearn.citylearn import CityLearnEnv\n",
+    "from citylearn.wrappers import StableBaselines3ActionWrapper\n",
     "\n",
     "# Initialize environment\n",
     "dataset_name = 'citylearn_challenge_2022_phase_1'\n",
@@ -908,7 +922,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.8.16"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gym>=0.21.0
-numpy==1.21.6
+numpy>=1.21.6
 pandas==1.3.5
 scikit-learn==1.0.2
 simplejson
-torch==1.12.0
-torchvision==0.13.0
+torch>=1.12.0
+torchvision>=0.13.0


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes in this pull request.
Changed requirements.txt so M2 Mac users can use CityLearn. This means relaxing some of the hard requirements.
M2 Mac users can install some of the requirements via these methods:
- https://developer.apple.com/metal/tensorflow-plugin/
- https://developer.apple.com/metal/pytorch/

Fixed the sb3 examples file to work again after refactoring

## Issue

N/A

## Changes

Changes to requirements.txt and sb3_examples.ipynb

## Screenshots

Please provide any relevant screenshots, if applicable.

## Checklist

- [ X ] I have tested the changes locally and they work as intended.
- [ X ] I have updated the documentation, if applicable.
- [ N/A ] I have added new tests, if applicable.
- [ X ] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [ X ] I have followed the project's code style and conventions.

## Additional notes

Please provide any additional information that may be helpful for the reviewer.
