### PR TITLE
Meta city rl updates

### DIFF
--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -1260,12 +1260,13 @@ class DynamicsBuilding(Building):
         Other keyword arguments used to initialize :py:class:`citylearn.building.Building` super class.
     """
 
-    def __init__(self, *args: Any, cooling_dynamics: Dynamics, heating_dynamics: Dynamics, **kwargs: Any):
+    def __init__(self, *args: Any, cooling_dynamics: Dynamics, heating_dynamics: Dynamics, ignore_dynamics: bool = None, **kwargs: Any):
         """Intialize `DynamicsBuilding`"""
 
         self.cooling_dynamics = cooling_dynamics
         self.heating_dynamics = heating_dynamics
         self.dynamics = None
+        self.ignore_dynamics = False if ignore_dynamics is None else ignore_dynamics
         super().__init__(*args, **kwargs)
         
 
@@ -1313,7 +1314,7 @@ class LSTMDynamicsBuilding(DynamicsBuilding):
     def simulate_dynamics(self) -> bool:
         """Whether to predict indoor dry-bulb temperature at current `time_step`."""
 
-        return self.dynamics._model_input[0][0] is not None
+        return not self.ignore_dynamics and self.dynamics._model_input[0][0] is not None
     
     def next_time_step(self):
         """Update the dynamics model input time series, Advance all energy storage and electric devices,

--- a/citylearn/data/baeda_3dem/Building_1.csv
+++ b/citylearn/data/baeda_3dem/Building_1.csv
@@ -1,4 +1,4 @@
-Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating
+Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating]
 6,1,1,1,28.1219624277523,0,49.774185554176,0.567641894272677,0,0.0,0,0.0,0.0,30.0,0
 6,2,1,1,27.9394669265402,0,49.8430953522941,0.567641894272677,0,0.0,0,0.0,0.0,30.0,0
 6,3,1,1,27.7802986138837,0,49.9654446181981,0.567641894272677,0,0.0,0,0.0,0.0,30.0,0

--- a/citylearn/data/baeda_3dem/Building_2.csv
+++ b/citylearn/data/baeda_3dem/Building_2.csv
@@ -1,4 +1,4 @@
-Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating
+Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating]
 6,1,1,1,24.9699100724587,0,43.7764805104256,1.77158941559471,0.0,0.0,0,0.0,0.0,30,0
 6,2,1,1,24.7039544367133,0,43.6902505803896,1.77158941559471,0.0,0.0,0,0.0,0.0,30,0
 6,3,1,1,24.4627176478405,0,43.5202381401768,1.77158941559471,0.350738348968432,0.0,0,0.0,0.0,30,0

--- a/citylearn/data/baeda_3dem/Building_3.csv
+++ b/citylearn/data/baeda_3dem/Building_3.csv
@@ -1,4 +1,4 @@
-Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating
+Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating]
 6,1,1,1,24.8811349201403,0,48.2465681076641,2.62751415513652,0.0,0.0,0,0.0,0.0,30,0
 6,2,1,1,24.998186793217,0,48.6258423394229,3.42752123270479,0.0,0.0,0,0.0,0.0,30,0
 6,3,1,1,24.769238250437,0,49.7865235108716,2.62751415513652,0.0,0.0,0,0.0,0.0,30,0

--- a/citylearn/data/baeda_3dem/Building_4.csv
+++ b/citylearn/data/baeda_3dem/Building_4.csv
@@ -1,4 +1,4 @@
-Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating
+Month,Hour,Day Type,Daylight Savings Status,Indoor Temperature [C],Average Unmet Cooling Setpoint Difference [C],Indoor Relative Humidity [%],Equipment Electric Power [kWh],DHW Heating [kWh],Cooling Load [kWh],Heating Load [kWh],Solar Generation [W/kW],Occupant Count [people],Temperature Set Point [C],HVAC Mode [Off/Cooling/Heating]
 6,1,1,1,27.3379489434958,0,59.8788140016393,9.27775041704389,0.0,0.0,0,0.0,0.0,30,0
 6,2,1,1,27.2356566510284,0,59.9971648101971,9.27775041704389,0.0,0.0,0,0.0,0.0,30,0
 6,3,1,1,27.1387782275827,0,60.2840639295413,9.27775041704389,0.0,0.0,0,0.0,0.0,30,0


### PR DESCRIPTION
## Description

Added support for customizable `temperature_epsilon` when estimating indoor temperature and setpoint observation limits as well ability to completely ignore temperature dynamics for `DynamicsBuilding`.

## Issue

None

## Changes

Changes to `Building` module and baeda_3dem building data headers.

## Screenshots

None

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [ ] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

## Additional notes

None
