### PR TITLE
Develop split episode training

### DIFF
--- a/citylearn/agents/base.py
+++ b/citylearn/agents/base.py
@@ -1,4 +1,3 @@
-import inspect
 import logging
 from typing import Any, List, Mapping
 from gym import spaces
@@ -31,14 +30,11 @@ class Agent(Environment):
         self.action_space = self.env.action_space
         self.episode_time_steps = self.env.time_steps
         self.building_metadata = self.env.get_metadata()['buildings']
-
-        arg_spec = inspect.getfullargspec(super().__init__)
-        kwargs = {
-            key:value for (key, value) in kwargs.items()
-            if (key in arg_spec.args or (arg_spec.varkw is not None))
-            
-        }
-        super().__init__(**kwargs)
+        super().__init__(
+            seconds_per_time_step=self.env.seconds_per_time_step,
+            random_seed=self.env.random_seed,
+            episode_tracker=env.episode_tracker,
+        )
 
     @property
     def observation_names(self) -> List[List[str]]:
@@ -130,6 +126,7 @@ class Agent(Environment):
         for episode in range(episodes):
             deterministic = deterministic or (deterministic_finish and episode >= episodes - 1)
             observations = self.env.reset()
+            self.episode_time_steps = self.episode_tracker.episode_time_steps
             done = False
             time_step = 0
             rewards_list = []

--- a/citylearn/base.py
+++ b/citylearn/base.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, List, Mapping, Tuple
+from typing import Any, List, Mapping, Tuple, Union
 import uuid
 import numpy as np
 
@@ -72,23 +72,20 @@ class EpisodeTracker:
 
         return self.__episode_end_time_step
 
-    def next_episode(
-            self, episode_time_steps: int, rolling_episode_split: bool, 
-            random_episode: bool, random_seed: int, episode_splits: List[Tuple[int, int]] = None
-    ):
+    def next_episode(self, episode_time_steps: Union[int, List[Tuple[int, int]]], rolling_episode_split: bool, random_episode: bool, random_seed: int):
         """Advance to next episode and set `episode_start_time_step` and `episode_end_time_step` for reading data files.
         
         Parameters
         ----------
-        episode_time_steps: int
-            Number of time steps in an episode. Defaults to (`simulation_end_time_step` - `simulation_start_time_step`) + 1.
-        rolling_episode_split: bool
-            True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes as (`simulation_end_time_step` - `simulation_start_time_step`) + 1)/`episode_time_steps`.
-        random_episode: bool
+        episode_time_steps: Union[int, List[Tuple[int, int]]], optional
+            If type is `int`, it is the number of time steps in an episode. If type is `List[Tuple[int, int]]]` is provided, it is a list of 
+            episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. Defaults to (`simulation_end_time_step` 
+        - `simulation_start_time_step`) + 1. Will ignore `rolling_episode_split` if `episode_splits` is of type `List[Tuple[int, int]]]`.
+        rolling_episode_split: bool, default: False
+            True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes 
+            in steps of `episode_time_steps`.
+        random_episode: bool, default: False
             True if episode splits are to be selected at random during training otherwise, False to select sequentially.
-        episode_splits: List[Tuple[int, int]]
-            A list of episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. 
-            Will ignore `episode_time_step` and `rolling_episode_split` if `episode_splits` is specified.
         """
 
         self.__episode += 1
@@ -97,18 +94,15 @@ class EpisodeTracker:
             rolling_episode_split,
             random_episode,
             random_seed,
-            episode_splits
         )
         
-    def __next_episode_time_steps(self, episode_time_steps: int, rolling_episode_split: bool, 
-            random_episode: bool, random_seed: int, episode_splits: List[Tuple[int, int]] = None
-    ):
+    def __next_episode_time_steps(self, episode_time_steps: Union[int, List[Tuple[int, int]]], rolling_episode_split: bool, random_episode: bool, random_seed: int):
         """Sets `episode_start_time_step` and `episode_end_time_step` for reading data files."""
 
         splits = None
 
-        if episode_splits is not None:
-            splits = episode_splits
+        if isinstance(episode_time_steps, List):
+            splits = episode_time_steps
 
         else:
             earliest_start_time_step = self.__simulation_start_time_step 

--- a/citylearn/base.py
+++ b/citylearn/base.py
@@ -1,6 +1,137 @@
 import random
-from typing import Any, Mapping
+from typing import Any, List, Mapping, Tuple
 import uuid
+import numpy as np
+
+class EpisodeTracker:
+    """Class for keeping track of current episode time steps for reading observations from data files.
+
+    An EpisodeTracker object is shared amongst the environment, buildings in environment and all descendant 
+    building devices. The object however, should be updated at the environment level only so that its changes 
+    propagate to all other evironment decscendants. `simulation_start_time_step` and `simulation_end_time_step`
+    are useful to separate training data from test data in the same data file. There may be one or more episodes betweeen 
+    `simulation_start_time_step` and `simulation_end_time_step` and their values should be defined in `schema` 
+    or parsed to :py:class:`citylearn.citylearn.CityLearnEnv.__init__`. Both `simulation_start_time_step` and 
+    `simulation_end_time_step` are used to select time series for building device and storage sizing as well as 
+    action and observation space estimation in :py:class:`citylearn.buiLding.Building`.
+
+    Parameters
+    ----------
+    simulation_start_time_step: int
+        Time step to start reading from data files. 
+    simulation_end_time_step: int
+        Time step to end reading from data files.
+    """
+    
+    def __init__(self, simulation_start_time_step: int, simulation_end_time_step: int):
+        self.__episode = -2
+        self.__episode_start_time_step = None
+        self.__episode_end_time_step = None
+        self.__simulation_start_time_step = simulation_start_time_step
+        self.__simulation_end_time_step = simulation_end_time_step
+
+    @property
+    def episode(self):
+        """Current episode index"""
+
+        return self.__episode
+    
+    @property
+    def episode_time_steps(self):
+        """Number of time steps in current episode split."""
+
+        return (self.episode_end_time_step - self.episode_start_time_step) + 1
+    
+    @property
+    def simulation_time_steps(self):
+        """Number of time steps between `simulation_start_time_step` and `simulation_end_time_step`."""
+
+        return (self.__simulation_end_time_step - self.__simulation_start_time_step) + 1
+    
+    @property
+    def simulation_start_time_step(self):
+        """Time step to start reading from data files."""
+
+        return self.__simulation_start_time_step
+    
+    @property
+    def simulation_end_time_step(self):
+        """Time step to end reading from data files."""
+
+        return self.__simulation_end_time_step
+    
+    @property
+    def episode_start_time_step(self):
+        """Start time step in current episode split."""
+
+        return self.__episode_start_time_step
+    
+    @property
+    def episode_end_time_step(self):
+        """End time step in current episode split."""
+
+        return self.__episode_end_time_step
+
+    def next_episode(
+            self, episode_time_steps: int, rolling_episode_split: bool, 
+            random_episode: bool, random_seed: int, episode_splits: List[Tuple[int, int]] = None
+    ):
+        """Advance to next episode and set `episode_start_time_step` and `episode_end_time_step` for reading data files.
+        
+        Parameters
+        ----------
+        episode_time_steps: int
+            Number of time steps in an episode. Defaults to (`simulation_end_time_step` - `simulation_start_time_step`) + 1.
+        rolling_episode_split: bool
+            True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes as (`simulation_end_time_step` - `simulation_start_time_step`) + 1)/`episode_time_steps`.
+        random_episode: bool
+            True if episode splits are to be selected at random during training otherwise, False to select sequentially.
+        episode_splits: List[Tuple[int, int]]
+            A list of episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. 
+            Will ignore `episode_time_step` and `rolling_episode_split` if `episode_splits` is specified.
+        """
+
+        self.__episode += 1
+        self.__next_episode_time_steps(
+            episode_time_steps,
+            rolling_episode_split,
+            random_episode,
+            random_seed,
+            episode_splits
+        )
+        
+    def __next_episode_time_steps(self, episode_time_steps: int, rolling_episode_split: bool, 
+            random_episode: bool, random_seed: int, episode_splits: List[Tuple[int, int]] = None
+    ):
+        """Sets `episode_start_time_step` and `episode_end_time_step` for reading data files."""
+
+        splits = None
+
+        if episode_splits is not None:
+            splits = episode_splits
+
+        else:
+            earliest_start_time_step = self.__simulation_start_time_step 
+            latest_start_time_step = (self.__simulation_end_time_step + 1) - episode_time_steps
+            
+            if rolling_episode_split:
+                start_time_steps = range(earliest_start_time_step, latest_start_time_step + 1)
+            else:
+                start_time_steps = range(earliest_start_time_step, latest_start_time_step + 1, episode_time_steps)
+
+            end_time_steps = np.array(start_time_steps, dtype=int) + episode_time_steps - 1
+            splits = np.array([start_time_steps, end_time_steps], dtype=int).T
+            splits = splits.tolist()
+
+        if random_episode:
+            seed = int(random_seed*(self.episode + 1))
+            np.random.seed(seed)
+            ix = np.random.choice(len(splits) - 1)
+
+        else:
+            ix = self.episode%len(splits)
+
+        self.__episode_start_time_step, self.__episode_end_time_step = splits[ix]
 
 class Environment:
     """Base class for all `citylearn` classes that have a spatio-temporal dimension.
@@ -11,14 +142,20 @@ class Environment:
         Number of seconds in 1 `time_step` and must be set to >= 1.
     random_seed : int, optional
         Pseudorandom number generator seed for repeatable results.
+    simulation_start_time_step: int, optional
+        Time step to start reading from data files. Should be set at the :py:class:`citylearn.citylearn.CityLearnEnv` level so that it propagates to other descendant objects.
+    simulation_end_time_step: int, optional
+        Time step to end reading from data files. Should be set at the :py:class:`citylearn.citylearn.CityLearnEnv` level so that it propagates to other descendant objects.
+    episode_tracker: EpisodeTracker, optional
+        :py:class:`citylearn.base.EpisodeTracker` object used to keep track of current episode time steps for reading observations from data files.
     """
     
-    def __init__(self, seconds_per_time_step: float = None, random_seed: int = None):
+    def __init__(self, seconds_per_time_step: float = None, random_seed: int = None, episode_tracker: EpisodeTracker = None):
         self.seconds_per_time_step = seconds_per_time_step
         self.__uid = uuid.uuid4().hex
         self.random_seed = random_seed
         self.__time_step = None
-        self.reset()
+        self.episode_tracker = episode_tracker
 
     @property
     def uid(self) -> str:
@@ -31,6 +168,13 @@ class Environment:
         """Pseudorandom number generator seed for repeatable results."""
 
         return self.__random_seed
+    
+    @property
+    def episode_tracker(self) -> EpisodeTracker:
+        """:py:class:`citylearn.base.EpisodeTracker` object used to keep track of 
+        current episode time steps for reading observations from data files."""
+
+        return self.__episode_tracker
 
     @property
     def time_step(self) -> int:
@@ -57,12 +201,17 @@ class Environment:
             assert seconds_per_time_step >= 1, 'seconds_per_time_step >= 1'
             self.__seconds_per_time_step = seconds_per_time_step
 
+    @episode_tracker.setter
+    def episode_tracker(self, episode_tracker: EpisodeTracker):
+        self.__episode_tracker = episode_tracker
+
     def get_metadata(self) -> Mapping[str, Any]:
         """Returns general static information."""
 
         return {
             'uid': self.uid,
             'random_seed': self.random_seed,
+            'simulation_time_steps': self.episode_tracker.simulation_time_steps,
             'seconds_per_time_step': self.seconds_per_time_step
         }
 

--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -1,10 +1,9 @@
-import inspect
 import math
 from typing import Any, List, Mapping, Tuple, Union
 from gym import spaces
 import numpy as np
 import torch
-from citylearn.base import Environment
+from citylearn.base import Environment, EpisodeTracker
 from citylearn.data import EnergySimulation, CarbonIntensity, Pricing, Weather
 from citylearn.dynamics import Dynamics, LSTMDynamics
 from citylearn.energy_model import Battery, ElectricHeater, HeatPump, PV, StorageTank
@@ -23,6 +22,9 @@ class Building(Environment):
         Mapping of active and inactive observations.
     action_metadata : dict
         Mapping od active and inactive actions.
+    episode_tracker: EpisodeTracker, optional
+        :py:class:`citylearn.base.EpisodeTracker` object used to keep track of current episode time steps 
+        for reading observations from data files.
     carbon_intensity : CarbonIntensity, optional
         Carbon dioxide emission rate time series.
     pricing : Pricing, optional
@@ -55,16 +57,12 @@ class Building(Environment):
     """
     
     def __init__(
-        self, energy_simulation: EnergySimulation, weather: Weather, observation_metadata: Mapping[str, bool], action_metadata: Mapping[str, bool], carbon_intensity: CarbonIntensity = None, 
+        self, energy_simulation: EnergySimulation, weather: Weather, observation_metadata: Mapping[str, bool], action_metadata: Mapping[str, bool], episode_tracker: EpisodeTracker, carbon_intensity: CarbonIntensity = None, 
         pricing: Pricing = None, dhw_storage: StorageTank = None, cooling_storage: StorageTank = None, heating_storage: StorageTank = None, electrical_storage: Battery = None, 
         dhw_device: Union[HeatPump, ElectricHeater] = None, cooling_device: HeatPump = None, heating_device: Union[HeatPump, ElectricHeater] = None, pv: PV = None, name: str = None,
         maximum_temperature_delta: float = None, **kwargs: Any
-    ):
+    ):  
         self.name = name
-        self.energy_simulation = energy_simulation
-        self.weather = weather
-        self.carbon_intensity = carbon_intensity
-        self.pricing = pricing
         self.dhw_storage = dhw_storage
         self.cooling_storage = cooling_storage
         self.heating_storage = heating_storage
@@ -73,23 +71,24 @@ class Building(Environment):
         self.cooling_device = cooling_device
         self.heating_device = heating_device
         self.pv = pv
+        super().__init__(
+            seconds_per_time_step=kwargs.get('seconds_per_time_step'),
+            random_seed=kwargs.get('randon_seed'),
+            episode_tracker=episode_tracker
+        )
+        self.energy_simulation = energy_simulation
+        self.weather = weather
+        self.carbon_intensity = carbon_intensity
+        self.pricing = pricing
         self.observation_metadata = observation_metadata
         self.action_metadata = action_metadata
         self.__observation_epsilon = 0.0 # to avoid out of bound observations
-        self.maximum_temperature_delta = 5.0 if maximum_temperature_delta is None else maximum_temperature_delta # C
+        self.maximum_temperature_delta = 10.0 if maximum_temperature_delta is None else maximum_temperature_delta # C
         self.__thermal_load_factor = 1.15
         self.non_periodic_normalized_observation_space_limits = None
         self.periodic_normalized_observation_space_limits = None
-        self.observation_space = self.estimate_observation_space()
+        self.observation_space = self.estimate_observation_space(include_all=False, normalize=False)
         self.action_space = self.estimate_action_space()
-        self.__set_without_partial_load_variables()
-
-        arg_spec = inspect.getfullargspec(super().__init__)
-        kwargs = {
-            key:value for (key, value) in kwargs.items()
-            if (key in arg_spec.args or (arg_spec.varkw is not None))
-        }
-        super().__init__(**kwargs)
 
     @property
     def energy_simulation(self) -> EnergySimulation:
@@ -283,7 +282,7 @@ class Building(Environment):
         This is the demand when heating_device is not controlled and always supplies ideal load.
         """
 
-        return self.__heating_demand_without_partial_load[0:self.time_step + 1]
+        return self.energy_simulation.heating_demand_without_control[0:self.time_step + 1]
 
     @property
     def cooling_demand_without_partial_load(self) -> np.ndarray:
@@ -292,7 +291,7 @@ class Building(Environment):
         This is the demand when cooling_device is not controlled and always supplies ideal load.
         """
 
-        return self.__cooling_demand_without_partial_load[0:self.time_step + 1]
+        return self.energy_simulation.cooling_demand_without_control[0:self.time_step + 1]
     
     @property
     def indoor_dry_bulb_temperature_without_partial_load(self) -> np.ndarray:
@@ -302,7 +301,7 @@ class Building(Environment):
         are not controlled and always supply ideal load.
         """
 
-        return self.__indoor_dry_bulb_temperature_without_partial_load[0:self.time_step + 1]
+        return self.energy_simulation.indoor_dry_bulb_temperature_without_control[0:self.time_step + 1]
 
     @property
     def net_electricity_consumption_emission_without_storage(self) -> np.ndarray:
@@ -541,7 +540,6 @@ class Building(Environment):
     @energy_simulation.setter
     def energy_simulation(self, energy_simulation: EnergySimulation):
         self.__energy_simulation = energy_simulation
-        self.__set_without_partial_load_variables()
 
     @weather.setter
     def weather(self, weather: Weather):
@@ -558,7 +556,7 @@ class Building(Environment):
     @carbon_intensity.setter
     def carbon_intensity(self, carbon_intensity: CarbonIntensity):
         if carbon_intensity is None:
-            self.__carbon_intensity = CarbonIntensity(np.zeros(len(self.energy_simulation.hour), dtype = float))
+            self.__carbon_intensity = CarbonIntensity(np.zeros(self.episode_tracker.simulation_time_steps, dtype = float))
         else:
             self.__carbon_intensity = carbon_intensity
 
@@ -566,10 +564,10 @@ class Building(Environment):
     def pricing(self, pricing: Pricing):
         if pricing is None:
             self.__pricing = Pricing(
-                np.zeros(len(self.energy_simulation.hour), dtype = float),
-                np.zeros(len(self.energy_simulation.hour), dtype = float),
-                np.zeros(len(self.energy_simulation.hour), dtype = float),
-                np.zeros(len(self.energy_simulation.hour), dtype = float),
+                np.zeros(self.episode_tracker.simulation_time_steps, dtype = float),
+                np.zeros(self.episode_tracker.simulation_time_steps, dtype = float),
+                np.zeros(self.episode_tracker.simulation_time_steps, dtype = float),
+                np.zeros(self.episode_tracker.simulation_time_steps, dtype = float),
             )
         else:
             self.__pricing = pricing
@@ -609,12 +607,8 @@ class Building(Environment):
     @observation_space.setter
     def observation_space(self, observation_space: spaces.Box):
         self.__observation_space = observation_space
-        self.non_periodic_normalized_observation_space_limits = self.estimate_observation_space_limits(
-            include_all=True, periodic_normalization=False
-        )
-        self.periodic_normalized_observation_space_limits = self.estimate_observation_space_limits(
-            include_all=True, periodic_normalization=True
-        )
+        self.non_periodic_normalized_observation_space_limits = self.estimate_observation_space_limits(include_all=True, periodic_normalization=False)
+        self.periodic_normalized_observation_space_limits = self.estimate_observation_space_limits(include_all=True, periodic_normalization=True)
 
     @action_space.setter
     def action_space(self, action_space: spaces.Box):
@@ -628,9 +622,20 @@ class Building(Environment):
     def random_seed(self, seed: int):
         Environment.random_seed.fset(self, seed)
 
+    @Environment.episode_tracker.setter
+    def episode_tracker(self, episode_tracker: EpisodeTracker):
+        Environment.episode_tracker.fset(self, episode_tracker)
+        self.cooling_device.episode_tracker = self.episode_tracker
+        self.heating_device.episode_tracker = self.episode_tracker
+        self.dhw_device.episode_tracker = self.episode_tracker
+        self.cooling_storage.episode_tracker = self.episode_tracker
+        self.heating_storage.episode_tracker = self.episode_tracker
+        self.dhw_storage.episode_tracker = self.episode_tracker
+        self.electrical_storage.episode_tracker = self.episode_tracker
+        self.pv.episode_tracker = self.episode_tracker
+
     def get_metadata(self) -> Mapping[str, Any]:
-        time_steps = len(self.energy_simulation.non_shiftable_load)
-        n_years = max(1, (time_steps*self.seconds_per_time_step)/(8760*3600))
+        n_years = max(1, (self.episode_tracker.episode_time_steps*self.seconds_per_time_step)/(8760*3600))
         return {
             **super().get_metadata(),
             'name': self.name,
@@ -681,9 +686,22 @@ class Building(Environment):
 
         observations = {}
         data = {
-            **{k: v[self.time_step] for k, v in vars(self.energy_simulation).items()},
-            **{k: v[self.time_step] for k, v in vars(self.weather).items()},
-            **{k: v[self.time_step] for k, v in vars(self.pricing).items()},
+            **{
+                k.lstrip('_'): self.energy_simulation.__getattr__(k.lstrip('_'))[self.time_step] 
+                for k, v in vars(self.energy_simulation).items() if isinstance(v, np.ndarray)
+            },
+            **{
+                k.lstrip('_'): self.weather.__getattr__(k.lstrip('_'))[self.time_step] 
+                for k, v in vars(self.weather).items() if isinstance(v, np.ndarray)
+            },
+            **{
+                k.lstrip('_'): self.pricing.__getattr__(k.lstrip('_'))[self.time_step] 
+                for k, v in vars(self.pricing).items() if isinstance(v, np.ndarray)
+            },
+            **{
+                k.lstrip('_'): self.carbon_intensity.__getattr__(k.lstrip('_'))[self.time_step] 
+                for k, v in vars(self.carbon_intensity).items() if isinstance(v, np.ndarray)
+            },
             'solar_generation':self.pv.get_generation(self.energy_simulation.solar_generation[self.time_step]),
             **{
                 'cooling_storage_soc':self.cooling_storage.soc[self.time_step],
@@ -692,7 +710,6 @@ class Building(Environment):
                 'electrical_storage_soc':self.electrical_storage.soc[self.time_step],
             },
             'net_electricity_consumption': self.__net_electricity_consumption[self.time_step],
-            **{k: v[self.time_step] for k, v in vars(self.carbon_intensity).items()},
             'cooling_device_cop': self.cooling_device.get_cop(self.weather.outdoor_dry_bulb_temperature[self.time_step], heating=False),
             'heating_device_cop': self.heating_device.get_cop(
                 self.weather.outdoor_dry_bulb_temperature[self.time_step], heating=True
@@ -739,6 +756,11 @@ class Building(Environment):
                 nm.x_min = low_limit[k]
                 nm.x_max = high_limit[k]
                 observations[k] = v*nm
+
+                # if nm.x_min <= v <= nm.x_max:
+                #     pass
+                # else:
+                #     print(k, v, nm.x_min, nm.x_max)
         else:
             pass
 
@@ -899,7 +921,7 @@ class Building(Environment):
         energy = action*self.electrical_storage.capacity
         self.electrical_storage.charge(energy)
 
-    def estimate_observation_space(self, include_all: bool = None, normalize: bool = None, periodic_normalization: bool = None) -> spaces.Box:
+    def estimate_observation_space(self, include_all: bool = None, normalize: bool = None) -> spaces.Box:
         r"""Get estimate of observation spaces.
 
         Parameters
@@ -908,8 +930,6 @@ class Building(Environment):
             Whether to estimate for all observations as listed in `observation_metadata` or only those that are active.
         normalize : bool, default: False
             Whether to apply min-max normalization bounded between [0, 1].
-        periodic_normalization: bool, default: False
-            Whether to apply sine-cosine normalization to cyclic observations including hour, day_type and month.
 
         Returns
         -------
@@ -918,12 +938,8 @@ class Building(Environment):
         """
 
         normalize = False if normalize is None else normalize
-        normalized_observation_space_limits = self.estimate_observation_space_limits(
-            include_all=include_all, periodic_normalization=True
-        )
-        unnormalized_observation_space_limits = self.estimate_observation_space_limits(
-            include_all=include_all, periodic_normalization=False
-        )
+        normalized_observation_space_limits = self.estimate_observation_space_limits(include_all=include_all, periodic_normalization=True)
+        unnormalized_observation_space_limits = self.estimate_observation_space_limits(include_all=include_all, periodic_normalization=False)
 
         if normalize:
             low_limit, high_limit = normalized_observation_space_limits
@@ -970,22 +986,44 @@ class Building(Environment):
         periodic_normalization = False if periodic_normalization is None else periodic_normalization
         periodic_observations = self.get_periodic_observation_metadata()
         low_limit, high_limit = {}, {}
+
+        # Use entire dataset length for space limit estimation
         data = {
-            'solar_generation':np.array(self.pv.get_generation(self.energy_simulation.solar_generation)),
-            **vars(self.energy_simulation),
-            **vars(self.weather),
-            **vars(self.carbon_intensity),
-            **vars(self.pricing),
+            'solar_generation':np.array(self.pv.get_generation(self.energy_simulation.__getattr__(
+                'solar_generation', 
+                start_time_step=self.episode_tracker.simulation_start_time_step, 
+                end_time_step=self.episode_tracker.simulation_end_time_step
+            ))),
+            **{k.lstrip('_'): self.energy_simulation.__getattr__(
+                k.lstrip('_'), 
+                start_time_step=self.episode_tracker.simulation_start_time_step, 
+                end_time_step=self.episode_tracker.simulation_end_time_step
+            ) for k in vars(self.energy_simulation)},
+            **{k.lstrip('_'): self.weather.__getattr__(
+                k.lstrip('_'), 
+                start_time_step=self.episode_tracker.simulation_start_time_step, 
+                end_time_step=self.episode_tracker.simulation_end_time_step
+            ) for k in vars(self.weather)},
+            **{k.lstrip('_'): self.carbon_intensity.__getattr__(
+                k.lstrip('_'), 
+                start_time_step=self.episode_tracker.simulation_start_time_step, 
+                end_time_step=self.episode_tracker.simulation_end_time_step
+            ) for k in vars(self.carbon_intensity)},
+            **{k.lstrip('_'): self.pricing.__getattr__(
+                k.lstrip('_'), 
+                start_time_step=self.episode_tracker.simulation_start_time_step, 
+                end_time_step=self.episode_tracker.simulation_end_time_step
+            ) for k in vars(self.pricing)},
         }
 
         for key in observation_names:
             if key == 'net_electricity_consumption':
                 # assumes devices and storages have been sized
-                low_limits = self.energy_simulation.non_shiftable_load - (
+                low_limits = data['non_shiftable_load'] - (
                     + self.electrical_storage.nominal_power
                         + data['solar_generation']
                 )
-                high_limits = self.energy_simulation.non_shiftable_load\
+                high_limits = data['non_shiftable_load']\
                     + self.cooling_device.nominal_power\
                         + self.heating_device.nominal_power\
                             + self.dhw_device.nominal_power\
@@ -1004,7 +1042,7 @@ class Building(Environment):
 
             elif key == 'net_electricity_consumption_without_storage_and_partial_load_and_pv':
                 low_limit[key] = 0.0
-                high_limits = self.energy_simulation.non_shiftable_load\
+                high_limits = data['non_shiftable_load']\
                     + self.cooling_device.nominal_power\
                         + self.heating_device.nominal_power\
                             + self.dhw_device.nominal_power
@@ -1015,13 +1053,13 @@ class Building(Environment):
                 high_limit[key] = 1.0
 
             elif key in ['cooling_device_cop']:
-                cop = self.cooling_device.get_cop(self.weather.outdoor_dry_bulb_temperature, heating=False)
+                cop = self.cooling_device.get_cop(data['outdoor_dry_bulb_temperature'], heating=False)
                 low_limit[key] = min(cop)
                 high_limit[key] = max(cop)
 
             elif key in ['heating_device_cop']:
                 if isinstance(self.heating_device, HeatPump):
-                    cop = self.heating_device.get_cop(self.weather.outdoor_dry_bulb_temperature, heating=True)
+                    cop = self.heating_device.get_cop(data['outdoor_dry_bulb_temperature'], heating=True)
                     low_limit[key] = min(cop)
                     high_limit[key] = max(cop)
                 else:
@@ -1029,8 +1067,8 @@ class Building(Environment):
                     high_limit[key] = self.heating_device.efficiency
 
             elif key == 'indoor_dry_bulb_temperature':
-                low_limit[key] = self.energy_simulation.indoor_dry_bulb_temperature.min() - self.maximum_temperature_delta
-                high_limit[key] = self.energy_simulation.indoor_dry_bulb_temperature.max() + self.maximum_temperature_delta
+                low_limit[key] = data['indoor_dry_bulb_temperature'].min() - self.maximum_temperature_delta
+                high_limit[key] = data['indoor_dry_bulb_temperature'].max() + self.maximum_temperature_delta
 
             elif key == 'indoor_dry_bulb_temperature_delta':
                 low_limit[key] = 0
@@ -1038,9 +1076,9 @@ class Building(Environment):
                 
             elif key in ['cooling_demand', 'heating_demand']:
                 if key == 'cooling_demand':
-                    max_demand = self.energy_simulation.cooling_demand.max()
+                    max_demand = data['cooling_demand'].max()
                 else:
-                    max_demand = self.energy_simulation.heating_demand.max()
+                    max_demand = data['heating_demand'].max()
 
                 low_limit[key] = 0.0
                 high_limit[key] = max_demand*self.__thermal_load_factor
@@ -1093,15 +1131,30 @@ class Building(Environment):
             else:
                 if key == 'cooling_storage':
                     capacity = self.cooling_storage.capacity
-                    maximum_demand = self.energy_simulation.cooling_demand.max()
+                    cooling_demand = self.energy_simulation.__getattr__(
+                        'cooling_demand', 
+                        start_time_step=self.episode_tracker.simulation_start_time_step, 
+                        end_time_step=self.episode_tracker.simulation_end_time_step
+                    )
+                    maximum_demand = cooling_demand.max()
                 
                 elif key == 'heating_storage':
                     capacity = self.heating_storage.capacity
-                    maximum_demand = self.energy_simulation.heating_demand.max()
+                    heating_demand = self.energy_simulation.__getattr__(
+                        'heating_demand', 
+                        start_time_step=self.episode_tracker.simulation_start_time_step, 
+                        end_time_step=self.episode_tracker.simulation_end_time_step
+                    )
+                    maximum_demand = heating_demand.max()
 
                 elif key == 'dhw_storage':
                     capacity = self.dhw_storage.capacity
-                    maximum_demand = self.energy_simulation.dhw_demand.max()
+                    dhw_demand = self.energy_simulation.__getattr__(
+                        'dhw_demand', 
+                        start_time_step=self.episode_tracker.simulation_start_time_step, 
+                        end_time_step=self.episode_tracker.simulation_end_time_step
+                    )
+                    maximum_demand = dhw_demand.max()
 
                 else:
                     raise Exception(f'Unknown action: {key}')
@@ -1116,14 +1169,6 @@ class Building(Environment):
                     high_limit.append(1.0)
  
         return spaces.Box(low=np.array(low_limit, dtype='float32'), high=np.array(high_limit, dtype='float32'))
-    
-    def __set_without_partial_load_variables(self):
-        """Set temperature and loads at their ideal state when neither 
-        cooling nor heating device is controlled to affect temperature."""
-
-        self.__cooling_demand_without_partial_load = self.energy_simulation.cooling_demand.copy()
-        self.__heating_demand_without_partial_load = self.energy_simulation.heating_demand.copy()
-        self.__indoor_dry_bulb_temperature_without_partial_load = self.energy_simulation.indoor_dry_bulb_temperature.copy()
 
     def autosize_cooling_device(self, **kwargs):
         """Autosize `cooling_device` `nominal_power` to minimum power needed to always meet `cooling_demand`.
@@ -1134,7 +1179,17 @@ class Building(Environment):
             Other keyword arguments parsed to `cooling_device` `autosize` function.
         """
 
-        self.cooling_device.autosize(self.weather.outdoor_dry_bulb_temperature, cooling_demand = self.energy_simulation.cooling_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'cooling_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        temperature = self.weather.__getattr__(
+            'outdoor_dry_bulb_temperature', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.cooling_device.autosize(temperature, cooling_demand=demand, **kwargs)
 
     def autosize_heating_device(self, **kwargs):
         """Autosize `heating_device` `nominal_power` to minimum power needed to always meet `heating_demand`.
@@ -1145,8 +1200,22 @@ class Building(Environment):
             Other keyword arguments parsed to `heating_device` `autosize` function.
         """
 
-        self.heating_device.autosize(self.weather.outdoor_dry_bulb_temperature, heating_demand = self.energy_simulation.heating_demand, **kwargs)\
-            if isinstance(self.heating_device, HeatPump) else self.heating_device.autosize(self.energy_simulation.heating_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'heating_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        temperature = self.weather.__getattr__(
+            'outdoor_dry_bulb_temperature', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+
+        if isinstance(self.heating_device, HeatPump):
+            self.heating_device.autosize(temperature, heating_demand=demand, **kwargs)
+
+        else:
+            self.heating_device.autosize(demand, **kwargs)
 
     def autosize_dhw_device(self, **kwargs):
         """Autosize `dhw_device` `nominal_power` to minimum power needed to always meet `dhw_demand`.
@@ -1157,8 +1226,22 @@ class Building(Environment):
             Other keyword arguments parsed to `dhw_device` `autosize` function.
         """
 
-        self.dhw_device.autosize(self.weather.outdoor_dry_bulb_temperature, heating_demand = self.energy_simulation.dhw_demand, **kwargs)\
-            if isinstance(self.dhw_device, HeatPump) else self.dhw_device.autosize(self.energy_simulation.dhw_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'dhw_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        temperature = self.weather.__getattr__(
+            'outdoor_dry_bulb_temperature', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+
+        if isinstance(self.dhw_device, HeatPump):
+            self.dhw_device.autosize(temperature, heating_demand=demand, **kwargs)
+
+        else:
+            self.dhw_device.autosize(demand, **kwargs)
 
     def autosize_cooling_storage(self, **kwargs):
         """Autosize `cooling_storage` `capacity` to minimum capacity needed to always meet `cooling_demand`.
@@ -1169,7 +1252,12 @@ class Building(Environment):
             Other keyword arguments parsed to `cooling_storage` `autosize` function.
         """
 
-        self.cooling_storage.autosize(self.energy_simulation.cooling_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'cooling_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.cooling_storage.autosize(demand, **kwargs)
 
     def autosize_heating_storage(self, **kwargs):
         """Autosize `heating_storage` `capacity` to minimum capacity needed to always meet `heating_demand`.
@@ -1180,7 +1268,12 @@ class Building(Environment):
             Other keyword arguments parsed to `heating_storage` `autosize` function.
         """
 
-        self.heating_storage.autosize(self.energy_simulation.heating_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'heating_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.heating_storage.autosize(demand, **kwargs)
 
     def autosize_dhw_storage(self, **kwargs):
         """Autosize `dhw_storage` `capacity` to minimum capacity needed to always meet `dhw_demand`.
@@ -1191,7 +1284,12 @@ class Building(Environment):
             Other keyword arguments parsed to `dhw_storage` `autosize` function.
         """
 
-        self.dhw_storage.autosize(self.energy_simulation.dhw_demand, **kwargs)
+        demand = self.energy_simulation.__getattr__(
+            'dhw_demand', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.dhw_storage.autosize(demand, **kwargs)
 
     def autosize_electrical_storage(self, **kwargs):
         """Autosize `electrical_storage` `capacity` to minimum capacity needed to store maximum `solar_generation`.
@@ -1202,7 +1300,12 @@ class Building(Environment):
             Other keyword arguments parsed to `electrical_storage` `autosize` function.
         """
 
-        self.electrical_storage.autosize(self.pv.get_generation(self.energy_simulation.solar_generation), **kwargs)
+        solar_generation = self.energy_simulation.__getattr__(
+            'solar_generation', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.electrical_storage.autosize(self.pv.get_generation(solar_generation), **kwargs)
 
     def autosize_pv(self, **kwargs):
         """Autosize `PV` `nominal_pwer` to minimum nominal_power needed to output maximum `solar_generation`.
@@ -1213,7 +1316,12 @@ class Building(Environment):
             Other keyword arguments parsed to `electrical_storage` `autosize` function.
         """
 
-        self.pv.autosize(self.pv.get_generation(self.energy_simulation.solar_generation), **kwargs)
+        solar_generation = self.energy_simulation.__getattr__(
+            'solar_generation', 
+            start_time_step=self.episode_tracker.simulation_start_time_step, 
+            end_time_step=self.episode_tracker.simulation_end_time_step
+        )
+        self.pv.autosize(self.pv.get_generation(solar_generation), **kwargs)
 
     def next_time_step(self):
         r"""Advance all energy storage and electric devices and, PV to next `time_step`."""
@@ -1244,19 +1352,31 @@ class Building(Environment):
         self.pv.reset()
 
         # variable reset
+        self.reset_datasets()
+        self.reset_dynamic_variables()
+        self.__solar_generation = self.pv.get_generation(self.energy_simulation.solar_generation)*-1
         self.__cooling_electricity_consumption = []
         self.__heating_electricity_consumption = []
         self.__dhw_electricity_consumption = []
-        self.__solar_generation = self.pv.get_generation(self.energy_simulation.solar_generation)*-1
         self.__net_electricity_consumption = []
         self.__net_electricity_consumption_emission = []
         self.__net_electricity_consumption_cost = []
         self.update_variables()
 
-        # reset controlled variables
-        self.energy_simulation.cooling_demand = self.__cooling_demand_without_partial_load.copy()
-        self.energy_simulation.heating_demand = self.__heating_demand_without_partial_load.copy()
-        self.energy_simulation.indoor_dry_bulb_temperature = self.__indoor_dry_bulb_temperature_without_partial_load.copy()
+    def reset_dynamic_variables(self):
+        self.energy_simulation.cooling_demand = self.energy_simulation.cooling_demand_without_control.copy()
+        self.energy_simulation.heating_demand = self.energy_simulation.heating_demand_without_control.copy()
+        self.energy_simulation.indoor_dry_bulb_temperature = self.energy_simulation.indoor_dry_bulb_temperature_without_control.copy()
+
+    def reset_datasets(self):
+        self.energy_simulation.start_time_step = self.episode_tracker.episode_start_time_step
+        self.weather.start_time_step = self.episode_tracker.episode_start_time_step
+        self.pricing.start_time_step = self.episode_tracker.episode_start_time_step
+        self.carbon_intensity.start_time_step = self.episode_tracker.episode_start_time_step
+        self.energy_simulation.end_time_step = self.episode_tracker.episode_end_time_step
+        self.weather.end_time_step = self.episode_tracker.episode_end_time_step
+        self.pricing.end_time_step = self.episode_tracker.episode_end_time_step
+        self.carbon_intensity.end_time_step = self.episode_tracker.episode_end_time_step
 
     def update_variables(self):
         """Update cooling, heating, dhw and net electricity consumption as well as net electricity consumption cost and carbon emissions."""

--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -1460,9 +1460,21 @@ class DynamicsBuilding(Building):
         """
 
         super().reset_dynamic_variables()
-        self.energy_simulation.cooling_demand = self.energy_simulation.cooling_demand_without_control.copy()
-        self.energy_simulation.heating_demand = self.energy_simulation.heating_demand_without_control.copy()
-        self.energy_simulation.indoor_dry_bulb_temperature = self.energy_simulation.indoor_dry_bulb_temperature_without_control.copy()
+        self.energy_simulation.cooling_demand = self.energy_simulation.__getattr__(
+            'cooling_demand_without_control', 
+            start_time_step=self.episode_tracker.simulation_start_time_step,
+            end_time_step=self.episode_tracker.simulation_end_time_step,
+        ).copy()
+        self.energy_simulation.heating_demand = self.energy_simulation.__getattr__(
+            'heating_demand_without_control', 
+            start_time_step=self.episode_tracker.simulation_start_time_step,
+            end_time_step=self.episode_tracker.simulation_end_time_step,
+        ).copy()
+        self.energy_simulation.indoor_dry_bulb_temperature = self.energy_simulation.__getattr__(
+            'indoor_dry_bulb_temperature_without_control', 
+            start_time_step=self.episode_tracker.simulation_start_time_step,
+            end_time_step=self.episode_tracker.simulation_end_time_step,
+        ).copy()
         
     def set_dynamics(self) -> Dynamics:
         """Resets and returns `cooling_dynamics` if current time step HVAC mode is off or

--- a/citylearn/citylearn.py
+++ b/citylearn/citylearn.py
@@ -9,7 +9,7 @@ from gym import Env, spaces
 import numpy as np
 import pandas as pd
 from citylearn import __version__ as citylearn_version
-from citylearn.base import Environment
+from citylearn.base import Environment, EpisodeTracker
 from citylearn.building import Building
 from citylearn.cost_function import CostFunction
 from citylearn.data import DataSet, EnergySimulation, CarbonIntensity, Pricing, Weather
@@ -42,22 +42,33 @@ class CityLearnEnv(Environment, Env):
         Name of CityLearn data set, filepath to JSON representation or :code:`dict` object of a CityLearn schema.
         Call :py:meth:`citylearn.data.DataSet.get_names` for list of available CityLearn data sets.
     root_directory: Union[str, Path]
-        Absolute path to directory that contains the data files including the schema. If provided, will override :code:`root_directory` definition in schema.
+        Absolute path to directory that contains the data files including the schema.
     buildings: Union[List[Building], List[str], List[int]], optional
         Buildings to include in environment. If list of :code:`citylearn.building.Building` is provided, will override :code:`buildings` definition in schema.
         If list of :str: is provided will include only schema :code:`buildings` keys that are contained in provided list of :code:`str`.
         If list of :int: is provided will include only schema :code:`buildings` whose index is contained in provided list of :code:`int`.
     simulation_start_time_step: int, optional
-        Time step to start reading from data files. If provided, will override :code:`simulation_start_time_step` definition in schema.
+        Time step to start reading data files contents.
     simulation_end_time_step: int, optional
-        Time step to end reading from data files. If provided, will override :code:`simulation_end_time_step` definition in schema.
+        Time step to end reading from data files contents.
+    episode_time_steps: int, optional
+        Number of time steps in an episode. Defaults to (`simulation_end_time_step` - `simulation_start_time_step`) + 1.
+    rolling_episode_split: bool, default: False
+        True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes 
+        as (()`simulation_end_time_step` - `simulation_start_time_step`) + 1)/`episode_time_steps`.
+    random_episode: bool, default: False
+        True if episode splits are to be selected at random during training otherwise, False to select sequentially.
+    episode_splits: List[Tuple[int, int]], optional
+        A list of episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. 
+        Will ignore `episode_time_step` and `rolling_episode_split` if `episode_splits` is specified.
+    seconds_per_time_step: float
+            Number of seconds in 1 `time_step` and must be set to >= 1.
     reward_function: RewardFunction, optional
         Reward function class instance. If provided, will override :code:`reward_function` definition in schema.
     central_agent: bool, optional
-        Expect 1 central agent to control all buildings. If provided, will override :code:`central` definition in schema.
+        Expect 1 central agent to control all buildings.
     shared_observations: List[str], optional
         Names of common observations across all buildings i.e. observations that have the same value irrespective of the building.
-        If provided, will override :code:`observations:<observation>:shared_in_central_agent` definitions in schema.
     random_seed: int, optional
         Pseudorandom number generator seed for repeatable results.
 
@@ -65,33 +76,57 @@ class CityLearnEnv(Environment, Env):
     ----------------
     **kwargs : dict
         Other keyword arguments used to initialize super classes.
+
+    Notes
+    -----
+    Parameters passed to `citylearn.citylearn.CityLearnEnv.__init__` that are also defined in `schema` will override their `schema` definition.
     """
     
     def __init__(self, 
         schema: Union[str, Path, Mapping[str, Any]], root_directory: Union[str, Path] = None, buildings: Union[List[Building], List[str], List[int]] = None, 
-        simulation_start_time_step: int = None, simulation_end_time_step: int = None, reward_function: RewardFunction = None, central_agent: bool = None, 
-        shared_observations: List[str] = None, random_seed: int = None, **kwargs: Any
+        simulation_start_time_step: int = None, simulation_end_time_step: int = None, episode_time_steps: int = None, rolling_episode_split: bool = None, 
+        random_episode: bool = None, episode_splits: List[Tuple[int, int]] = None, seconds_per_time_step: float = None, reward_function: RewardFunction = None, 
+        central_agent: bool = None, shared_observations: List[str] = None, random_seed: int = None, **kwargs: Any
     ):
         self.schema = schema
         self.__rewards = None
         self.random_seed = random_seed
-        self.root_directory, self.buildings, self.simulation_start_time_step, self.simulation_end_time_step, self.seconds_per_time_step,\
-            self.reward_function, self.central_agent, self.shared_observations = self._load(
-                root_directory=root_directory,
-                buildings=buildings,
-                simulation_start_time_step=simulation_start_time_step,
-                simulation_end_time_step=simulation_end_time_step,
-                reward_function=reward_function,
-                central_agent=central_agent,
-                shared_observations=shared_observations,
-                random_seed=self.random_seed,
-            )
-        
-        super().__init__(**kwargs)
+        args = self._load(
+            root_directory=root_directory,
+            buildings=buildings,
+            simulation_start_time_step=simulation_start_time_step,
+            simulation_end_time_step=simulation_end_time_step,
+            episode_time_steps=episode_time_steps,
+            rolling_episode_split=rolling_episode_split,
+            random_episode=random_episode,
+            episode_splits=episode_splits,
+            seconds_per_time_step=seconds_per_time_step,
+            reward_function=reward_function,
+            central_agent=central_agent,
+            shared_observations=shared_observations,
+            random_seed=self.random_seed,
+        )
+        self.root_directory = args[0]
+        self.buildings = args[1]
 
-        # update the metadata for reward function after initializing environment
+        # now call super class initialization and set episode tracker now that buildings are set
+        super().__init__(seconds_per_time_step=args[6], random_seed=self.random_seed, episode_tracker=args[10])
+
+        # set other class variables
+        self.episode_time_steps = args[2]
+        self.rolling_episode_split = args[3]
+        self.random_episode = args[4]
+        self.episode_splits = args[5]
+        self.central_agent = args[8]
+        self.shared_observations = args[9]
+
+        # reset environment
+        self.reset()
+
+        # set reward function
+        self.reward_function = args[7]
         self.reward_function.env_metadata = self.get_metadata()
-
+        
     @property
     def schema(self) -> Union[str, Path, Mapping[str, Any]]:
         """Filepath to JSON representation or `dict` object of CityLearn schema."""
@@ -109,24 +144,44 @@ class CityLearnEnv(Environment, Env):
         """Buildings in CityLearn environment."""
 
         return self.__buildings
-
-    @property
-    def simulation_start_time_step(self) -> int:
-        """Time step to start reading from data files."""
-
-        return self.__simulation_start_time_step
-
-    @property
-    def simulation_end_time_step(self) -> int:
-        """Time step to end reading from data files."""
-
-        return self.__simulation_end_time_step
-
+    
     @property
     def time_steps(self) -> int:
-        """Number of simulation time steps."""
+        """Number of time steps in current episode split."""
+        
+        return self.episode_tracker.episode_time_steps
 
-        return (self.simulation_end_time_step - self.simulation_start_time_step) + 1
+    @property
+    def episode_time_steps(self) -> int:
+        """Number of time steps in an episode. Defaults to (`simulation_end_time_step` - `simulation_start_time_step`) + 1."""
+
+        return self.__episode_time_steps
+    
+    @property
+    def rolling_episode_split(self) -> bool:
+        """True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, 
+        False to split episodes as (()`simulation_end_time_step` - `simulation_start_time_step`) + 1)/`episode_time_steps`."""
+
+        return self.__rolling_episode_split
+    
+    @property
+    def episode_splits(self) -> List[Tuple[int, int]]:
+        """A list of episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. 
+        Will ignore `episode_time_step` and `rolling_episode_split` if `episode_splits` is specified."""
+
+        return self.__episode_splits
+    
+    @property
+    def random_episode(self) -> bool:
+        """True if episode splits are to be selected at random during training otherwise, False to select sequentially."""
+
+        return self.__random_episode
+    
+    @property
+    def episode(self) -> int:
+        """Current episode index."""
+
+        return self.episode_tracker.episode
 
     @property
     def reward_function(self) -> RewardFunction:
@@ -540,15 +595,28 @@ class CityLearnEnv(Environment, Env):
     def buildings(self, buildings: List[Building]):
         self.__buildings = buildings
 
-    @simulation_start_time_step.setter
-    def simulation_start_time_step(self, simulation_start_time_step: int):
-        assert simulation_start_time_step >= 0, 'simulation_start_time_step must be >= 0'
-        self.__simulation_start_time_step = simulation_start_time_step
+    @Environment.episode_tracker.setter
+    def episode_tracker(self, episode_tracker: EpisodeTracker):
+        Environment.episode_tracker.fset(self, episode_tracker)
 
-    @simulation_end_time_step.setter
-    def simulation_end_time_step(self, simulation_end_time_step: int):
-        assert simulation_end_time_step >= 0, 'simulation_end_time_step must be >= 0'
-        self.__simulation_end_time_step = simulation_end_time_step
+        for b in self.buildings:
+            b.episode_tracker = self.episode_tracker
+
+    @episode_time_steps.setter
+    def episode_time_steps(self, episode_time_steps: int):
+        self.__episode_time_steps = self.episode_tracker.simulation_time_steps if episode_time_steps is None else episode_time_steps
+
+    @rolling_episode_split.setter
+    def rolling_episode_split(self, rolling_episode_split: bool):
+        self.__rolling_episode_split = False if rolling_episode_split is None else rolling_episode_split
+
+    @random_episode.setter
+    def random_episode(self, random_episode: bool):
+        self.__random_episode = False if random_episode is None else random_episode
+
+    @episode_splits.setter
+    def episode_splits(self, episode_splits: List[Tuple[int, int]]):
+        self.__episode_splits = episode_splits
 
     @reward_function.setter
     def reward_function(self, reward_function: RewardFunction):
@@ -565,7 +633,6 @@ class CityLearnEnv(Environment, Env):
     def get_metadata(self) -> Mapping[str, Any]:
         return {
             **super().get_metadata(),
-            'time_steps': self.time_steps,
             'reward_function': self.reward_function.__class__.__name__,
             'central_agent': self.central_agent,
             'shared_observations': self.shared_observations,
@@ -909,11 +976,20 @@ class CityLearnEnv(Environment, Env):
         Returns
         -------
         observations: List[List[float]]
-            :attr:`observations`. 
+            :attr:`observations`.
         """
 
         # object reset
         super().reset()
+
+        # update time steps for time series
+        self.episode_tracker.next_episode(
+            self.episode_time_steps,
+            self.rolling_episode_split,
+            self.random_episode,
+            self.random_seed,
+            episode_splits=self.episode_splits
+        )
 
         for building in self.buildings:
             building.reset()
@@ -960,7 +1036,7 @@ class CityLearnEnv(Environment, Env):
         agent = agent_constructor(**agent_attributes)
         return agent
 
-    def _load(self, **kwargs) -> Tuple[Union[Path, str], List[Building], int, int, float, RewardFunction, bool, List[str]]:
+    def _load(self, **kwargs) -> Tuple[Union[Path, str], List[Building], int, bool, bool, List[Tuple[int, int]], float, RewardFunction, bool, List[str], EpisodeTracker]:
         """Return `CityLearnEnv` and `Controller` objects as defined by the `schema`.
         
         Returns
@@ -969,17 +1045,23 @@ class CityLearnEnv(Environment, Env):
             Absolute path to directory that contains the data files including the schema.
         buildings : List[Building]
             Buildings in CityLearn environment.
-        simulation_start_time_step: int
-            Time step to start reading from data files.
-        simulation_end_time_step: int
-            Time step to end reading from data files.
+        episode_time_steps: int
+            Number of time steps in an episode. Defaults to (`simulation_end_time_step` - `simulation_start_time_step`) + 1.
+        rolling_episode_split: bool
+            True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes 
+            as (()`simulation_end_time_step` - `simulation_start_time_step`) + 1)/`episode_time_steps`.
+        random_episode: bool
+            True if episode splits are to be selected at random during training otherwise, False to select sequentially.
+        episode_splits: List[Tuple[int, int]]
+            A list of episode start and end time steps between `simulation_start_time_step` and `simulation_end_time_step`. 
+            Will ignore `episode_time_step` and `rolling_episode_split` if `episode_splits` is specified.
         seconds_per_time_step: float
             Number of seconds in 1 `time_step` and must be set to >= 1.
         reward_function : RewardFunction
             Reward function class instance.
-        central_agent : bool, optional
+        central_agent : bool
             Expect 1 central agent to control all building storage device.
-        shared_observations : List[str], optional
+        shared_observations : List[str]
             Names of common observations across all buildings i.e. observations that have the same value irrespective of the building.
         """
         
@@ -1008,13 +1090,22 @@ class CityLearnEnv(Environment, Env):
         simulation_end_time_step = kwargs['simulation_end_time_step'] if kwargs.get('simulation_end_time_step') is not None else\
             self.schema['simulation_end_time_step']
         random_seed = kwargs.get('random_seed', None)
-        seconds_per_time_step = self.schema['seconds_per_time_step']
+        episode_time_steps = kwargs['episode_time_steps'] if kwargs.get('episode_time_steps') is not None else self.schema.get('episode_time_steps', None)
+        rolling_episode_split = kwargs['rolling_episode_split'] if kwargs.get('rolling_episode_split') is not None else self.schema.get('rolling_episode_split', None)
+        random_episode = kwargs['random_episode'] if kwargs.get('random_episode') is not None else self.schema.get('random_episode', None)
+        episode_splits = kwargs['episode_splits'] if kwargs.get('episode_splits') is not None else self.schema.get('episode_splits', None)
+        seconds_per_time_step = kwargs['seconds_per_time_step'] if kwargs.get('seconds_per_time_step') is not None else self.schema['seconds_per_time_step']
+        episode_tracker = EpisodeTracker(simulation_start_time_step, simulation_end_time_step)
         buildings_to_include = list(self.schema['buildings'].keys())
         buildings = ()
 
         if kwargs.get('buildings') is not None and len(kwargs['buildings']) > 0:
             if isinstance(kwargs['buildings'][0], Building):
-                buildings = kwargs['buildings']
+                buildings: List[Building] = kwargs['buildings']
+
+                for b in buildings:
+                    b.episode_tracker = episode_tracker
+
                 buildings_to_include = []
             
             elif isinstance(kwargs['buildings'][0], str):
@@ -1032,20 +1123,20 @@ class CityLearnEnv(Environment, Env):
         for building_name in buildings_to_include:
             building_schema = self.schema['buildings'][building_name]
             # data
-            energy_simulation = pd.read_csv(os.path.join(root_directory,building_schema['energy_simulation'])).iloc[simulation_start_time_step:simulation_end_time_step + 1].copy()
+            energy_simulation = pd.read_csv(os.path.join(root_directory,building_schema['energy_simulation']))
             energy_simulation = EnergySimulation(*energy_simulation.values.T)
-            weather = pd.read_csv(os.path.join(root_directory,building_schema['weather'])).iloc[simulation_start_time_step:simulation_end_time_step + 1].copy()
+            weather = pd.read_csv(os.path.join(root_directory,building_schema['weather']))
             weather = Weather(*weather.values.T)
 
             if building_schema.get('carbon_intensity', None) is not None:
-                carbon_intensity = pd.read_csv(os.path.join(root_directory,building_schema['carbon_intensity'])).iloc[simulation_start_time_step:simulation_end_time_step + 1].copy()
+                carbon_intensity = pd.read_csv(os.path.join(root_directory,building_schema['carbon_intensity']))
                 carbon_intensity = carbon_intensity['kg_CO2/kWh'].tolist()
                 carbon_intensity = CarbonIntensity(carbon_intensity)
             else:
                 carbon_intensity = None
 
             if building_schema.get('pricing', None) is not None:
-                pricing = pd.read_csv(os.path.join(root_directory,building_schema['pricing'])).iloc[simulation_start_time_step:simulation_end_time_step + 1].copy()
+                pricing = pd.read_csv(os.path.join(root_directory,building_schema['pricing']))
                 pricing = Pricing(*pricing.values.T)
             else:
                 pricing = None
@@ -1090,6 +1181,7 @@ class CityLearnEnv(Environment, Env):
                 name=building_name, 
                 seconds_per_time_step=seconds_per_time_step,
                 random_seed=random_seed,
+                episode_tracker=episode_tracker,
                 **dynamics,
             )
 
@@ -1144,7 +1236,10 @@ class CityLearnEnv(Environment, Env):
             reward_function_constructor = getattr(importlib.import_module(reward_function_module), reward_function_name)
             reward_function = reward_function_constructor(None, **reward_function_attributes)
 
-        return root_directory, buildings, simulation_start_time_step, simulation_end_time_step, seconds_per_time_step, reward_function, central_agent, shared_observations
+        return (
+            root_directory, buildings, episode_time_steps, rolling_episode_split, random_episode, episode_splits, 
+            seconds_per_time_step, reward_function, central_agent, shared_observations, episode_tracker
+        )
         
 class Error(Exception):
     """Base class for other exceptions."""

--- a/citylearn/data.py
+++ b/citylearn/data.py
@@ -188,6 +188,15 @@ class EnergySimulation(TimeSeriesData):
         self.occupant_count = np.zeros(len(solar_generation), dtype=float) if occupant_count is None else np.array(occupant_count, dtype=float)
         self.indoor_dry_bulb_temperature_set_point = np.zeros(len(solar_generation), dtype=float) if indoor_dry_bulb_temperature_set_point is None else np.array(indoor_dry_bulb_temperature_set_point, dtype=float)
 
+        # set controlled variable defaults
+        self.indoor_dry_bulb_temperature_without_control = self.indoor_dry_bulb_temperature.copy()
+        self.cooling_demand_without_control = self.cooling_demand.copy()
+        self.heating_demand_without_control = self.heating_demand.copy()
+        self.dhw_demand_without_control = self.dhw_demand.copy()
+        self.non_shiftable_load_without_control = self.non_shiftable_load.copy()
+        self.indoor_relative_humidity_without_control = self.indoor_relative_humidity.copy()
+        self.indoor_dry_bulb_temperature_set_point_without_control = self.indoor_dry_bulb_temperature_set_point.copy()
+
         if hvac_mode is None:
             self.hvac_mode = np.zeros(len(solar_generation), dtype=float)*1 
         

--- a/citylearn/data.py
+++ b/citylearn/data.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 import shutil
-from typing import Iterable, List, Union
+from typing import Any, Iterable, List, Union
 import numpy as np
 
 from citylearn.utilities import read_json
@@ -71,8 +71,52 @@ class DataSet:
         schema['root_directory'] = root_directory
         
         return schema
+    
+class TimeSeriesData:
+    """Generic time series data class.
+    
+    
+    Parameters
+    ----------
+    variable: np.array, optional
+        A generic time series variable.
+    start_time_step: int, optional
+        Time step to start reading variables.
+    end_time_step: int, optional
+         Time step to end reading variables.
+    """
 
-class EnergySimulation:
+    def __init__(self, variable: Iterable = None, start_time_step: int = None, end_time_step: int = None):
+        self.variable = variable if variable is None else np.array(variable)
+        self.start_time_step = start_time_step
+        self.end_time_step = end_time_step
+
+    def __getattr__(self, name: str, start_time_step: int = None, end_time_step: int = None):
+        """Returns values of the named variable within the specified time steps and
+        is useful for selecting episode-specific observation."""
+        
+        # not the most elegant solution tbh
+        variable = self.__dict__[f'_{name}']
+        
+        if isinstance(variable, Iterable):
+            start_time_step = self.start_time_step if start_time_step is None else start_time_step
+            start_index = 0 if start_time_step is None else start_time_step
+            end_time_step = self.end_time_step if end_time_step is None else end_time_step
+            end_index = len(variable) if end_time_step is None else end_time_step + 1
+            return variable[start_index:end_index]
+        
+        else:
+            return variable
+        
+    def __setattr__(self, name: str, value: Any):
+        """Sets named variable.
+        
+        Variables are named with a single underscore prefix.
+        """
+
+        self.__dict__[f'_{name}'] = value
+
+class EnergySimulation(TimeSeriesData):
     """`Building` `energy_simulation` data class.
 
     Parameters
@@ -110,14 +154,19 @@ class EnergySimulation:
         the heat pump is available for space cooling and if 2, the heat pump and auxilliary electric heating are available
         for space heating only. The default is to set the mode to cooling at all times. The HVAC devices are always available
         for cooling and heating storage charging irrespective of the hvac mode.
+    start_time_step: int, optional
+        Time step to start reading variables.
+    end_time_step: int, optional
+         Time step to end reading variables.
     """
 
     def __init__(
         self, month: Iterable[int], hour: Iterable[int], day_type: Iterable[int],
         daylight_savings_status: Iterable[int], indoor_dry_bulb_temperature: Iterable[float], average_unmet_cooling_setpoint_difference: Iterable[float], indoor_relative_humidity: Iterable[float], 
         non_shiftable_load: Iterable[float], dhw_demand: Iterable[float], cooling_demand: Iterable[float], heating_demand: Iterable[float], solar_generation: Iterable[float], 
-        occupant_count: Iterable[int] = None, indoor_dry_bulb_temperature_set_point: Iterable[int] = None, hvac_mode: Iterable[int] = None
+        occupant_count: Iterable[int] = None, indoor_dry_bulb_temperature_set_point: Iterable[int] = None, hvac_mode: Iterable[int] = None, start_time_step: int = None, end_time_step: int = None
     ):
+        super().__init__(start_time_step=start_time_step, end_time_step=end_time_step)
         self.month = np.array(month, dtype = int)
         self.hour = np.array(hour, dtype = int)
         self.day_type = np.array(day_type, dtype = int)
@@ -154,7 +203,7 @@ class EnergySimulation:
             assert len(unique) == 0, f'Invalid hvac_mode values were found: {unique}. Valid values are 0, 1 and 2 to indicate off, cooling mode and heating mode.'
             self.hvac_mode = np.array(hvac_mode, dtype=int)
 
-class Weather:
+class Weather(TimeSeriesData):
     """`Building` `weather` data class.
 
     Parameters
@@ -191,6 +240,10 @@ class Weather:
         Direct solar irradiance 12 hours ahead prediction time series in [W/m^2].
     direct_solar_irradiance_predicted_24h : np.array
         Direct solar irradiance 24 hours ahead prediction time series in [W/m^2].
+    start_time_step: int, optional
+        Time step to start reading variables.
+    end_time_step: int, optional
+         Time step to end reading variables.
     """
 
     def __init__(
@@ -198,8 +251,9 @@ class Weather:
         outdoor_dry_bulb_temperature_predicted_6h: Iterable[float], outdoor_dry_bulb_temperature_predicted_12h: Iterable[float], outdoor_dry_bulb_temperature_predicted_24h: Iterable[float],
         outdoor_relative_humidity_predicted_6h: Iterable[float], outdoor_relative_humidity_predicted_12h: Iterable[float], outdoor_relative_humidity_predicted_24h: Iterable[float],
         diffuse_solar_irradiance_predicted_6h: Iterable[float], diffuse_solar_irradiance_predicted_12h: Iterable[float], diffuse_solar_irradiance_predicted_24h: Iterable[float],
-        direct_solar_irradiance_predicted_6h: Iterable[float], direct_solar_irradiance_predicted_12h: Iterable[float], direct_solar_irradiance_predicted_24h: Iterable[float],
+        direct_solar_irradiance_predicted_6h: Iterable[float], direct_solar_irradiance_predicted_12h: Iterable[float], direct_solar_irradiance_predicted_24h: Iterable[float], start_time_step: int = None, end_time_step: int = None
     ):
+        super().__init__(start_time_step=start_time_step, end_time_step=end_time_step)
         self.outdoor_dry_bulb_temperature = np.array(outdoor_dry_bulb_temperature, dtype = float)
         self.outdoor_relative_humidity = np.array(outdoor_relative_humidity, dtype = float)
         self.diffuse_solar_irradiance = np.array(diffuse_solar_irradiance, dtype = float)
@@ -217,7 +271,7 @@ class Weather:
         self.direct_solar_irradiance_predicted_12h = np.array(direct_solar_irradiance_predicted_12h, dtype = float)
         self.direct_solar_irradiance_predicted_24h = np.array(direct_solar_irradiance_predicted_24h, dtype = float)
 
-class Pricing:
+class Pricing(TimeSeriesData):
     """`Building` `pricing` data class.
 
     Parameters
@@ -230,25 +284,35 @@ class Pricing:
         Electricity pricing 12 hours ahead prediction time series in [$/kWh].
     electricity_pricing_predicted_24h : np.array
         Electricity pricing 24 hours ahead prediction time series in [$/kWh].
+    start_time_step: int, optional
+        Time step to start reading variables.
+    end_time_step: int, optional
+         Time step to end reading variables.
     """
 
     def __init__(
-        self, electricity_pricing: Iterable[float], electricity_pricing_predicted_6h: Iterable[float], 
-        electricity_pricing_predicted_12h: Iterable[float], electricity_pricing_predicted_24h: Iterable[float]
+        self, electricity_pricing: Iterable[float], electricity_pricing_predicted_6h: Iterable[float], electricity_pricing_predicted_12h: Iterable[float], 
+        electricity_pricing_predicted_24h: Iterable[float], start_time_step: int = None, end_time_step: int = None
     ):
+        super().__init__(start_time_step=start_time_step, end_time_step=end_time_step)
         self.electricity_pricing = np.array(electricity_pricing, dtype = float)
         self.electricity_pricing_predicted_6h = np.array(electricity_pricing_predicted_6h, dtype = float)
         self.electricity_pricing_predicted_12h = np.array(electricity_pricing_predicted_12h, dtype = float)
         self.electricity_pricing_predicted_24h = np.array(electricity_pricing_predicted_24h, dtype = float)
 
-class CarbonIntensity:
+class CarbonIntensity(TimeSeriesData):
     """`Building` `carbon_intensity` data class.
 
     Parameters
     ----------
     carbon_intensity : np.array
         Grid carbon emission rate time series in [kg_co2/kWh].
+    start_time_step: int, optional
+        Time step to start reading variables.
+    end_time_step: int, optional
+         Time step to end reading variables.
     """
 
-    def __init__(self, carbon_intensity: Iterable[float]):
+    def __init__(self, carbon_intensity: Iterable[float], start_time_step: int = None, end_time_step: int = None):
+        super().__init__(start_time_step=start_time_step, end_time_step=end_time_step)
         self.carbon_intensity = np.array(carbon_intensity, dtype = float)

--- a/citylearn/wrappers.py
+++ b/citylearn/wrappers.py
@@ -31,7 +31,7 @@ class NormalizedObservationWrapper(ObservationWrapper):
             shared_observations = []
 
             for i, b in enumerate(self.env.buildings):
-                s = b.estimate_observation_space(normalize=True, periodic_normalization=True)
+                s = b.estimate_observation_space(normalize=True)
                 o = b.observations(normalize=True, periodic_normalization=True)
 
                 for k, lv, hv in zip(o, s.low, s.high):
@@ -53,7 +53,7 @@ class NormalizedObservationWrapper(ObservationWrapper):
             observation_space = [spaces.Box(low=np.array(low_limit), high=np.array(high_limit), dtype=np.float32)]
 
         else:
-            observation_space = [b.estimate_observation_space(normalize=True, periodic_normalization=True) for b in self.env.buildings]
+            observation_space = [b.estimate_observation_space(normalize=True) for b in self.env.buildings]
         
         return observation_space
 

--- a/tests/compatibility_test.py
+++ b/tests/compatibility_test.py
@@ -3,28 +3,27 @@ import time
 import sys
 sys.path.insert(0, '..')
 from citylearn.agents.base import Agent
-from citylearn.agents.marlisa import MARLISA
+from citylearn.agents.marlisa import MARLISA, MARLISARBC
 from citylearn.agents.rbc import RBC, HourRBC, BasicRBC, OptimizedRBC, BasicBatteryRBC
-from citylearn.agents.sac import SAC, SACHourRBC, SACBasicRBC, SACOptimizedRBC, SACBasicBatteryRBC
+from citylearn.agents.sac import SAC, SACRBC
 from citylearn.citylearn import CityLearnEnv
 from citylearn.data import DataSet
 
 agents = [
-    # Agent, 
-    # RBC, 
-    # HourRBC, 
-    # BasicRBC, 
-    # OptimizedRBC, 
-    # BasicBatteryRBC,
-    # SAC,
-    # SACHourRBC,
-    # SACBasicRBC, 
-    # SACOptimizedRBC, 
-    # SACBasicBatteryRBC,
-    MARLISA
+    Agent, 
+    RBC, 
+    HourRBC, 
+    BasicRBC, 
+    OptimizedRBC, 
+    BasicBatteryRBC,
+    SAC,
+    SACRBC,
+    MARLISA,
+    MARLISARBC,
 ]
 schemas = [
     'baeda_3dem',
+    'citylearn_challenge_2020_climate_zone_1',
     'citylearn_challenge_2021', 
     'citylearn_challenge_2022_phase_all'
 ]
@@ -33,49 +32,49 @@ central_agent_setting = [
     False
 ]
 
-# # load all datasets
-# for schema in DataSet.get_names():
-#     try:
-#         env = CityLearnEnv(schema)
-#         print(f'Successfully loaded schema: "{schema}"')
-#     except Exception as e:
-#         print(f'Unsuccessfully loaded schema: "{schema}"')
-#         raise(e)
+# load all datasets
+for schema in DataSet.get_names():
+    try:
+        env = CityLearnEnv(schema)
+        print(f'Successfully loaded schema: "{schema}"')
+    except Exception as e:
+        print(f'Unsuccessfully loaded schema: "{schema}"')
+        raise(e)
     
-# # load all internally defined agents
-# for schema in schemas:
-#     for agent in agents:
-#         env = CityLearnEnv(schema)
-
-#         try:
-#             model = agent(env)
-#             print(f'Successfully loaded agent: "{model.__class__.__name__}" with schema: "{schema}"')
-#         except Exception as e:
-#             print(f'Unccessfully loaded agent: "{model.__class__.__name__}" with schema: "{schema}"')
-#             raise(e)
-        
-# train all internally defined agents with central and non-central agent
+# load all internally defined agents
 for schema in schemas:
     for agent in agents:
-        for central_agent in central_agent_setting:
-            if agent == MARLISA and central_agent:
-                continue
-            else:
-                pass
+        env = CityLearnEnv(schema)
 
-            env = CityLearnEnv(schema, central_agent=central_agent, simulation_start_time_step=0, simulation_end_time_step=1000)
+        try:
+            model = agent(env)
+            print(f'Successfully loaded agent: "{model.__class__.__name__}" with schema: "{schema}"')
+        except Exception as e:
+            print(f'Unccessfully loaded agent: "{model.__class__.__name__}" with schema: "{schema}"')
+            raise(e)
+        
+# # train all internally defined agents with central and non-central agent
+# for schema in schemas:
+#     for agent in agents:
+#         for central_agent in central_agent_setting:
+#             if agent == MARLISA and central_agent:
+#                 continue
+#             else:
+#                 pass
 
-            try:
-                model: Agent = agent(
-                    env, 
-                    standardize_start_time_step=env.time_steps - 1,
-                    end_exploration_time_step=env.time_steps
-                )
-                model.learn(episodes=3, deterministic_finish=True, logging_level=1)
-                print(f'Successfully trained agent: "{model.__class__.__name__}" with schema: "{schema}" and central_agent: "{central_agent}"')
-            except Exception as e:
-                print(f'Unccessfully trained agent: "{model.__class__.__name__}" with schema: "{schema}" and central_agent: "{central_agent}"')
-                raise(e)
+#             env = CityLearnEnv(schema, central_agent=central_agent, simulation_start_time_step=0, simulation_end_time_step=1000)
+
+#             try:
+#                 model: Agent = agent(
+#                     env, 
+#                     standardize_start_time_step=env.time_steps - 1,
+#                     end_exploration_time_step=env.time_steps
+#                 )
+#                 model.learn(episodes=3, deterministic_finish=True, logging_level=1)
+#                 print(f'Successfully trained agent: "{model.__class__.__name__}" with schema: "{schema}" and central_agent: "{central_agent}"')
+#             except Exception as e:
+#                 print(f'Unccessfully trained agent: "{model.__class__.__name__}" with schema: "{schema}" and central_agent: "{central_agent}"')
+#                 raise(e)
             
 # stable-baselines
 

--- a/tests/stable_baselines.py
+++ b/tests/stable_baselines.py
@@ -7,8 +7,7 @@ from citylearn.wrappers import NormalizedObservationWrapper, StableBaselines3Wra
 
 # Initialize environment
 dataset_name = 'baeda_3dem'
-env = CityLearnEnv(dataset_name, central_agent=True)
-env.buildings = env.buildings[0:1]
+env = CityLearnEnv(dataset_name, buildings=[0], central_agent=True)
 
 # Normalization wrapper
 env = NormalizedObservationWrapper(env)


### PR DESCRIPTION
## Description

Provide interface where a single dataset can be used to define multiple episodes. Until now, a dataset was used to define 1 episode of training that was repeatedly used to reset the environment and train multiple episodes. Problem with this approach was that it didn't allow for shorter episodes such as daily or weekly episodes while maintaining a dataset of many days. It also meant that there had to be continuity in time series e.g. 3 months of data from different years could not be easily combined into a training dataset.

This pull request allows one to specify the length of each episode using the `citylearn.citylearn.CityLearnEnv.episode_time_steps` variable such that setting this value to say `24` will mean each episode is 24 hours long and during each call to `citylearn.citylearn.CityLearnEnv.reset`, a new 24 timestep sequence in the dataset will be used for training. 

By default, `citylearn.citylearn.CityLearnEnv.episode_time_steps` is set to the usual length defined by `simulation_start_time_step` and `simulation_end_time_step` in `schema`.  

Alternatively, for unequal episode lengths, one can set `citylearn.citylearn.CityLearnEnv.episode_time_steps` to a list of `episode_start_time_step` and `episode_end_time_step` pairs e.g. `[[0, 10], [10, 50], [51, 60]]`. 

Other variables like `citylearn.citylearn.CityLearnEnv.rolling_episode_split` can be used to True if episode sequences are split such that each time step is a candidate for `episode_start_time_step` otherwise, False to split episodes in steps of `episode_time_steps`.

`citylearn.citylearn.CityLearnEnv.rolling_episode_split` is True if episode splits i.e. `episode_start_time_step` and `episode_end_time_step` are to be selected at random during training otherwise, False to select sequentially.

## Issue

NIL

## Changes

See change log

## Screenshots

NIL

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [x] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

## Additional notes

NIL
