### PR TITLE
included negative evaluation value error checking

### DIFF
--- a/citylearn/citylearn.py
+++ b/citylearn/citylearn.py
@@ -848,12 +848,12 @@ class CityLearnEnv(Environment, Env):
         evaluation = {
             'carbon_emissions_total': {'display_name': 'Carbon emissions', 'weight': 0.05},
             'discomfort_proportion': {'display_name': 'Unmet hours', 'weight': 0.15},
-            'ramping_average': {'display_name': 'Ramping', 'weight': 0.1},
-            'daily_one_minus_load_factor_average': {'display_name': 'Load factor', 'weight': 0.1},
-            'daily_peak_average': {'display_name': 'Daily peak', 'weight': 0.1},
-            'annual_peak_average': {'display_name': 'All-time peak', 'weight': 0.1},
-            'thermal_resilience_proportion': {'display_name': 'Thermal resilience', 'weight': 0.2},
-            'power_outage_normalized_unserved_energy_total': {'display_name': 'Unserved energy', 'weight': 0.2},
+            'ramping_average': {'display_name': 'Ramping', 'weight': 0.125},
+            'daily_one_minus_load_factor_average': {'display_name': 'Load factor', 'weight': 0.125},
+            'daily_peak_average': {'display_name': 'Daily peak', 'weight': 0.125},
+            'annual_peak_average': {'display_name': 'All-time peak', 'weight': 0.125},
+            'thermal_resilience_proportion': {'display_name': 'Thermal resilience', 'weight': 0.15},
+            'power_outage_normalized_unserved_energy_total': {'display_name': 'Unserved energy', 'weight': 0.15},
         }
         data = self.evaluate(
             control_condition=EvaluationCondition.WITH_STORAGE_AND_PARTIAL_LOAD_AND_PV,
@@ -863,12 +863,14 @@ class CityLearnEnv(Environment, Env):
         data = data[data['level']=='district'].set_index('cost_function').to_dict('index')
         evaluation = {k: {**v, 'value': data[k]['value']} for k, v in evaluation.items()}
         weight_sum = np.nansum([v['weight'] for _, v in evaluation.items()], dtype='float32')
-        value_sum = np.nansum([v['weight']*v['value'] for _, v in evaluation.items()], dtype='float32')
+        weighted_values = [v['weight']*v['value'] for _, v in evaluation.items()]
+        value_sum = np.nansum(weighted_values, dtype='float32')
         evaluation['average_score'] = {
             'display_name': 'Score',
             'weight': None,
             'value': value_sum/weight_sum
-        } 
+        }
+        assert np.nanmin(weighted_values) >= 0, f'Negative value error: {evaluation}.'
         
         return evaluation
     


### PR DESCRIPTION
## Description

Updated CityLearn Challenge 2023 weights and negative evaluation kpi check. 

Negative values are prohibited so a control solution that causes any of the KPIs to go to zero is not allowed and should be investigated as to why it is causing such. 

One possible reason is if most or all time steps experience net export thus causing average peak and load factor to have negative values during calculation as they make use of the net electricity consumption time series.

## Issue

NIL

## Changes

- Challenge KPI weights
- Negative KPI value prohibition

## Screenshots

NIL

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [x] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

## Additional notes

NIL
