### PR TITLE
Citylearn challenge 2023 power outage env

### DIFF
--- a/citylearn/citylearn.py
+++ b/citylearn/citylearn.py
@@ -849,7 +849,7 @@ class CityLearnEnv(Environment, Env):
             'daily_one_minus_load_factor_average': {'display_name': 'Load factor', 'weight': 0.075},
             'daily_peak_average': {'display_name': 'Daily peak', 'weight': 0.075},
             'annual_peak_average': {'display_name': 'All-time peak', 'weight': 0.075},
-            'thermal_resilience_proportion': {'display_name': 'Thermal resilience', 'weight': 0.15},
+            'one_minus_thermal_resilience_proportion': {'display_name': 'Thermal resilience', 'weight': 0.15},
             'power_outage_normalized_unserved_energy_total': {'display_name': 'Unserved energy', 'weight': 0.15},
         }
         data = self.evaluate(
@@ -966,8 +966,8 @@ class CityLearnEnv(Environment, Env):
                 'cost_function': 'discomfort_delta_average',
                 'value': average_delta[-1],
             }, {
-                'cost_function': 'thermal_resilience_proportion',
-                'value': CostFunction.thermal_resilience(power_outage=b.power_outage_signal, **discomfort_kwargs)[-1],
+                'cost_function': 'one_minus_thermal_resilience_proportion',
+                'value': CostFunction.one_minus_thermal_resilience(power_outage=b.power_outage_signal, **discomfort_kwargs)[-1],
             }, {
                 'cost_function': 'power_outage_normalized_unserved_energy_total',
                 'value': CostFunction.normalized_unserved_energy(expected_energy, served_energy, power_outage=b.power_outage_signal)[-1]

--- a/citylearn/cost_function.py
+++ b/citylearn/cost_function.py
@@ -274,7 +274,7 @@ class CostFunction:
         )
     
     @staticmethod
-    def thermal_resilience(power_outage: List[int], **kwargs):
+    def one_minus_thermal_resilience(power_outage: List[int], **kwargs):
         r"""Rolling percentage of discomfort time steps during power outage.
 
         Parameters


### PR DESCRIPTION
## Description

Renamed `citylearn.cost_function.CostFunction.thermal_resilience` to `citylearn.cost_function.CostFunctionone_minus_thermal_resilience` as is more reflective of what is calculated. The KPI is discomfort but only when there is a power outage.

## Issue

Please provide the issue number or link to the related issue, if applicable.

## Changes

Please list the changes introduced by this pull request.

## Screenshots

Please provide any relevant screenshots, if applicable.

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [x] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

## Additional notes

Please provide any additional information that may be helpful for the reviewer.
