### PR TITLE
fix: simple change to avoid division by zero in unserved_energy calc

### DIFF
--- a/citylearn/cost_function.py
+++ b/citylearn/cost_function.py
@@ -333,7 +333,7 @@ class CostFunction:
             'power_outage': [1]*len(served_energy) if power_outage is None else power_outage,
         })
         data['unserved_energy'] = data['expected_energy'] - data['served_energy']
-        data.loc[data['power_outage']==0, ('unserved_energy', 'expected_energy')] = (0.0, 0.0)
+        data.loc[data['power_outage']==0, 'unserved_energy'] = 0.0
         data['unserved_energy'] = data['unserved_energy'].rolling(window=data.shape[0], min_periods=1).sum()
         data['unserved_energy'] = data['unserved_energy']/data['expected_energy'].sum()
 


### PR DESCRIPTION
## Description
Simple fix in the unserved energy cost calculation.

## Issue

The problem lies in the `normalized_unserved_energy` function, in the line:
```python
data.loc[data['power_outage']==0, ('unserved_energy', 'expected_energy')] = (0.0, 0.0)
```
where the `expected_energy` is set to 0.0 for when there isn't a power outage.

As a result, when there is NO power outage for a given time series (i.e. `data['power_outage'].all() == True`), all of `data['expected_energy']` gets set to zero, which leads to a division by zero in:
```python
data['unserved_energy'] = data['unserved_energy']/data['expected_energy'].sum()
```

## Changes

Simple fix by only setting the `unserved_energy` to zero, and leaving the `expected_energy` as is:
```python
data.loc[data['power_outage']==0, 'unserved_energy'] = 0.0
```

## Screenshots

n/a

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [x] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

## Additional notes

As discussed on Discord with @kingsleynweye :)
