### PR TITLE
Fix subhourly discrepancies in Battery asset

### DIFF
--- a/citylearn/base.py
+++ b/citylearn/base.py
@@ -211,7 +211,13 @@ class Environment:
         r"""Number of seconds in 1 time step."""
 
         return self.__seconds_per_time_step
-    
+
+    @property
+    def hours_per_time_step(self) -> float:
+        r"""Number of hours in 1 time step."""
+
+        return self.__seconds_per_time_step / 3600.0
+
     @property
     def numpy_random_state(self) -> np.random.RandomState:
         """Nupy random state object."""

--- a/citylearn/base.py
+++ b/citylearn/base.py
@@ -211,7 +211,7 @@ class Environment:
         r"""Number of seconds in 1 time step."""
 
         return self.__seconds_per_time_step
-
+    
     @property
     def hours_per_time_step(self) -> float:
         r"""Number of hours in 1 time step."""

--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -1599,8 +1599,7 @@ class Building(Environment):
         power = action * self.electrical_storage.nominal_power  # kW
 
         # Convert power (kW) to energy (kWh) based on time step duration
-        time_step_hours_ratio = self.hours_per_time_step
-        energy = power * time_step_hours_ratio  # Energy in kWh
+        energy = power * self.hours_per_time_step  # Energy in kWh
 
         # Optionally clamp to flexibility range if needed
         energy = min(energy, self.downward_electrical_flexibility)
@@ -1691,7 +1690,7 @@ class Building(Environment):
         total_charger_power_kw += sum(getattr(charger, 'max_charging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
         total_charger_power_kw += sum(getattr(charger, 'max_discharging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
         total_storage_power_kw = float(getattr(self.electrical_storage, 'nominal_power', 0.0) or 0.0)
-        max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.hours_per_time_step)
+        max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * self.hours_per_time_step
 
         for key in observation_names:
             if key.startswith('charging_phase_one_hot_'):
@@ -1948,7 +1947,7 @@ class Building(Environment):
             total_charger_power_kw += sum(getattr(charger, 'max_charging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
             total_charger_power_kw += sum(getattr(charger, 'max_discharging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
             total_storage_power_kw = float(getattr(self.electrical_storage, 'nominal_power', 0.0) or 0.0)
-            max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.hours_per_time_step)
+            max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * self.hours_per_time_step
             data['charging_constraint_violation_kwh'] = np.array([0.0, max_violation_energy], dtype='float32')
 
             phase_one_hot_keys = getattr(self, '_phase_encoding_observation_keys', []) or []

--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -11,7 +11,7 @@ from citylearn.base import Environment, EpisodeTracker
 from citylearn.data import CarbonIntensity, EnergySimulation, Pricing, TOLERANCE, Weather, ZERO_DIVISION_PLACEHOLDER
 from citylearn.dynamics import Dynamics, LSTMDynamics
 from citylearn.electric_vehicle_charger import Charger
-from citylearn.energy_model import Battery, ElectricDevice, ElectricHeater, HeatPump, PV, StorageDevice, StorageTank, WashingMachine
+from citylearn.energy_model import Battery, ElectricDevice, ElectricHeater, HeatPump, PV, StorageTank, WashingMachine
 from citylearn.internal.building_ops import BuildingOpsService
 from citylearn.occupant import LogisticRegressionOccupant, Occupant
 from citylearn.power_outage import PowerOutage
@@ -1478,7 +1478,7 @@ class Building(Environment):
             demand = self.cooling_demand[self.time_step]
             energy = max(-demand, energy)
 
-        self.cooling_storage.charge(self._convert_energy_for_storage(self.cooling_storage, energy))
+        self.cooling_storage.charge(energy)
         charged_energy = max(self.cooling_storage.energy_balance[self.time_step], 0.0)
         electricity_consumption = self.cooling_device.get_input_power(charged_energy, temperature, heating=False)
         self.cooling_device.update_electricity_consumption(electricity_consumption)
@@ -1527,7 +1527,7 @@ class Building(Environment):
             demand = self.heating_demand[self.time_step]
             energy = max(-demand, energy)
 
-        self.heating_storage.charge(self._convert_energy_for_storage(self.heating_storage, energy))
+        self.heating_storage.charge(energy)
         charged_energy = max(self.heating_storage.energy_balance[self.time_step], 0.0)
         electricity_consumption = self.heating_device.get_input_power(charged_energy, temperature, heating=True) \
             if isinstance(self.heating_device, HeatPump) else self.heating_device.get_input_power(charged_energy)
@@ -1572,7 +1572,7 @@ class Building(Environment):
             demand = self.dhw_demand[self.time_step]
             energy = max(-demand, energy)
 
-        self.dhw_storage.charge(self._convert_energy_for_storage(self.dhw_storage, energy))
+        self.dhw_storage.charge(energy)
         charged_energy = max(self.dhw_storage.energy_balance[self.time_step], 0.0)
         electricity_consumption = self.dhw_device.get_input_power(charged_energy, temperature, heating=True) \
             if isinstance(self.dhw_device, HeatPump) else self.dhw_device.get_input_power(charged_energy)
@@ -1606,18 +1606,7 @@ class Building(Environment):
         energy = min(energy, self.downward_electrical_flexibility)
 
 
-        self.electrical_storage.charge(self._convert_energy_for_storage(self.electrical_storage, energy))
-
-    @staticmethod
-    def _convert_energy_for_storage(storage: StorageDevice, energy: float) -> float:
-        """Convert energy for storage models that expect dataset-resolution values."""
-
-        ratio = getattr(storage, 'time_step_ratio', None)
-
-        if ratio in (None, 0):
-            return energy
-
-        return energy / ratio
+        self.electrical_storage.charge(energy)
 
     def ___demand_limit_check(self, end_use: str, demand: float, max_device_output: float):
         message = f'timestep: {self.time_step}, building: {self.name}, outage: {self.power_outage}, demand: {demand},' \

--- a/citylearn/building.py
+++ b/citylearn/building.py
@@ -118,7 +118,7 @@ class Building(Environment):
             episode_tracker=episode_tracker,
             time_step_ratio=self.time_step_ratio,
         )
-        self.algorithm_action_based_time_step_hours_ratio = self.seconds_per_time_step / 3600
+        self.algorithm_action_based_time_step_hours_ratio = self.hours_per_time_step
         self.stochastic_power_outage_model = stochastic_power_outage_model
         self.washing_machines = washing_machines
         self.electric_vehicle_chargers = electric_vehicle_chargers
@@ -1599,7 +1599,7 @@ class Building(Environment):
         power = action * self.electrical_storage.nominal_power  # kW
 
         # Convert power (kW) to energy (kWh) based on time step duration
-        time_step_hours_ratio = self.seconds_per_time_step / 3600  # Convert seconds to fraction of hour
+        time_step_hours_ratio = self.hours_per_time_step
         energy = power * time_step_hours_ratio  # Energy in kWh
 
         # Optionally clamp to flexibility range if needed
@@ -1702,7 +1702,7 @@ class Building(Environment):
         total_charger_power_kw += sum(getattr(charger, 'max_charging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
         total_charger_power_kw += sum(getattr(charger, 'max_discharging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
         total_storage_power_kw = float(getattr(self.electrical_storage, 'nominal_power', 0.0) or 0.0)
-        max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.seconds_per_time_step / 3600)
+        max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.hours_per_time_step)
 
         for key in observation_names:
             if key.startswith('charging_phase_one_hot_'):
@@ -1959,7 +1959,7 @@ class Building(Environment):
             total_charger_power_kw += sum(getattr(charger, 'max_charging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
             total_charger_power_kw += sum(getattr(charger, 'max_discharging_power', 0.0) or 0.0 for charger in self.electric_vehicle_chargers)
             total_storage_power_kw = float(getattr(self.electrical_storage, 'nominal_power', 0.0) or 0.0)
-            max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.seconds_per_time_step / 3600)
+            max_violation_energy = (total_charger_power_kw + total_storage_power_kw) * (self.hours_per_time_step)
             data['charging_constraint_violation_kwh'] = np.array([0.0, max_violation_energy], dtype='float32')
 
             phase_one_hot_keys = getattr(self, '_phase_encoding_observation_keys', []) or []

--- a/citylearn/electric_vehicle_charger.py
+++ b/citylearn/electric_vehicle_charger.py
@@ -340,10 +340,7 @@ class Charger(Environment):
         if self.connected_electric_vehicle:
             electric_vehicle = self.connected_electric_vehicle
 
-            # Battery model expects dataset-resolution energy. Convert from control-step kWh when needed.
-            ratio = getattr(electric_vehicle.battery, 'time_step_ratio', None)
-            battery_command = battery_energy_kwh if ratio in (None, 0) else battery_energy_kwh / ratio
-            electric_vehicle.battery.charge(battery_command)
+            electric_vehicle.battery.charge(battery_energy_kwh)
 
             battery_energy_balance = electric_vehicle.battery.energy_balance[self.time_step]
             self.__electricity_consumption[self.time_step] = (

--- a/citylearn/energy_model.py
+++ b/citylearn/energy_model.py
@@ -686,7 +686,7 @@ class StorageDevice(Device):
 
     @property
     def energy_init(self) -> float:
-        r"""Latest energy level after accounting for standby hourly lossses in [kWh]."""
+        r"""Latest energy level after accounting for standby losses over 1 `time_step` in [kWh]."""
         time_step_loss_coefficient = 1.0 - (1.0 - self.loss_coefficient)**self.hours_per_time_step
 
         if self.time_step == 0:

--- a/citylearn/energy_model.py
+++ b/citylearn/energy_model.py
@@ -670,7 +670,7 @@ class StorageDevice(Device):
     def loss_coefficient(self) -> float:
         r"""Standby hourly losses."""
 
-        return self.__loss_coefficient * self.time_step_ratio
+        return self.__loss_coefficient
     
     @property
     def initial_soc(self) -> float:
@@ -687,9 +687,11 @@ class StorageDevice(Device):
     @property
     def energy_init(self) -> float:
         r"""Latest energy level after accounting for standby hourly lossses in [kWh]."""
+        time_step_loss_coefficient = 1.0 - (1.0 - self.loss_coefficient)**self.hours_per_time_step
+
         if self.time_step == 0:
-            return max(0.0, self.__soc[self.time_step]*self.capacity*(1 - self.loss_coefficient))
-        return max(0.0, self.__soc[self.time_step - 1]*self.capacity*(1 - self.loss_coefficient))
+            return max(0.0, self.__soc[self.time_step]*self.capacity*(1 - time_step_loss_coefficient))
+        return max(0.0, self.__soc[self.time_step - 1]*self.capacity*(1 - time_step_loss_coefficient))
 
     @property
     def energy_balance(self) -> np.ndarray:

--- a/citylearn/energy_model.py
+++ b/citylearn/energy_model.py
@@ -757,7 +757,6 @@ class StorageDevice(Device):
         If charging, soc = min(`soc_init` + energy*`round_trip_efficiency`, `capacity`)
         If discharging, soc = max(0, `soc_init` + energy/`round_trip_efficiency`)
         """
-        energy = energy * self.time_step_ratio
         energy_init = self.energy_init
         # The initial State Of Charge (SOC) is the previous SOC minus the energy losses
         energy_final = min(energy_init + energy*self.round_trip_efficiency, self.capacity) if energy >= 0\
@@ -888,12 +887,12 @@ class StorageTank(StorageDevice):
         If charging, soc = min(`soc_init` + energy*`efficiency`, `max_input_power`, `capacity`)
         If discharging, soc = max(0, `soc_init` + energy/`efficiency`, `max_output_power`)
         """
-        energy = energy * self.time_step_ratio
-
         if energy >= 0:    
-            energy = energy if self.max_input_power is None else np.nanmin([energy, self.max_input_power])
+            energy = energy if self.max_input_power is None \
+                else np.nanmin([energy, self.max_input_power*self.hours_per_time_step])
         else:
-            energy = energy if self.max_output_power is None else np.nanmax([-self.max_output_power, energy])
+            energy = energy if self.max_output_power is None \
+                else np.nanmax([-self.max_output_power*self.hours_per_time_step, energy])
         
         super().charge(energy)
 
@@ -1065,25 +1064,24 @@ class Battery(StorageDevice, ElectricDevice):
 
         if energy >= 0:
             energy_wrt_degrade = self.degraded_capacity - self.energy_init
-            max_input_power = self.get_max_input_power()
-            energy = min(max_input_power, self.available_nominal_power, energy_wrt_degrade, energy)
-            self.efficiency = self.get_current_efficiency(min(action_energy, max_input_power))
+            max_input_energy = self.get_max_input_power() * self.hours_per_time_step
+            available_nominal_energy = self.nominal_power * self.hours_per_time_step - self.electricity_consumption[self.time_step]
+            energy = min(max_input_energy, available_nominal_energy, energy_wrt_degrade, energy)
+            self.efficiency = self.get_current_efficiency(min(action_energy, max_input_energy))
 
         else:
             soc_limit_wrt_dod = 1.0 - self.depth_of_discharge
             soc_init = self.soc[self.time_step - 1] if self.time_step > 0 else self.soc[self.time_step]
             soc_difference = soc_init - soc_limit_wrt_dod
             energy_limit_wrt_dod = max(soc_difference * self.capacity * self.round_trip_efficiency, 0.0) * -1
-            max_output_power = self.get_max_output_power()
-            energy = max(-max_output_power, energy_limit_wrt_dod, energy)
-            self.efficiency = self.get_current_efficiency(min(abs(action_energy), max_output_power))
+            max_output_energy = self.get_max_output_power() * self.hours_per_time_step
+            energy = max(-max_output_energy, energy_limit_wrt_dod, energy)
+            self.efficiency = self.get_current_efficiency(min(abs(action_energy), max_output_energy))
 
         super().charge(energy)
         degraded_capacity = max(self.degraded_capacity - self.degrade(), 0.0)
         self._capacity_history.append(degraded_capacity)
-        ratio = self.time_step_ratio if self.time_step_ratio not in (None, 0) else 1.0
-        dataset_resolution_balance = self.energy_balance[self.time_step]/ratio
-        self.update_electricity_consumption(dataset_resolution_balance, enforce_polarity=False)
+        self.update_electricity_consumption(self.energy_balance[self.time_step], enforce_polarity=False)
 
     def get_max_output_power(self) -> float:
         r"""Get maximum output power while considering `capacity_power_curve` limitations if defined otherwise, returns `nominal_power`.
@@ -1128,7 +1126,8 @@ class Battery(StorageDevice, ElectricDevice):
         """
 
         # Calculating the maximum power rate at which the battery can be charged or discharged
-        energy_normalized = np.abs(energy)/max(self.nominal_power, ZERO_DIVISION_PLACEHOLDER)
+        energy_normalized = np.abs(energy)/max(
+            self.nominal_power * self.hours_per_time_step, ZERO_DIVISION_PLACEHOLDER)
         idx = max(0, np.argmax(energy_normalized <= self.power_efficiency_curve[0]) - 1)
         efficiency = self.power_efficiency_curve[1][idx]\
             + (energy_normalized - self.power_efficiency_curve[0][idx]

--- a/citylearn/energy_model.py
+++ b/citylearn/energy_model.py
@@ -1081,7 +1081,9 @@ class Battery(StorageDevice, ElectricDevice):
         super().charge(energy)
         degraded_capacity = max(self.degraded_capacity - self.degrade(), 0.0)
         self._capacity_history.append(degraded_capacity)
-        self.update_electricity_consumption(self.energy_balance[self.time_step], enforce_polarity=False)
+        ratio = self.time_step_ratio if self.time_step_ratio not in (None, 0) else 1.0
+        dataset_resolution_balance = self.energy_balance[self.time_step]/ratio
+        self.update_electricity_consumption(dataset_resolution_balance, enforce_polarity=False)
 
     def get_max_output_power(self) -> float:
         r"""Get maximum output power while considering `capacity_power_curve` limitations if defined otherwise, returns `nominal_power`.

--- a/citylearn/internal/building_ops.py
+++ b/citylearn/internal/building_ops.py
@@ -772,7 +772,7 @@ class BuildingOpsService:
                     'phase_power_kw': {},
                 }
 
-            penalty_kwh = self._safe_scalar(violation_kw * (building.seconds_per_time_step / 3600), 0.0)
+            penalty_kwh = self._safe_scalar(violation_kw * (building.hours_per_time_step), 0.0)
             building._charging_constraint_penalty_kwh = penalty_kwh
             building._charging_constraint_last_penalty_kwh = penalty_kwh
             phase_power = {}
@@ -929,7 +929,7 @@ class BuildingOpsService:
             'phase_power_kw': phase_kw,
         }
 
-        penalty_kwh = self._safe_scalar(violation_kw * (building.seconds_per_time_step / 3600.0), 0.0)
+        penalty_kwh = self._safe_scalar(violation_kw * (building.hours_per_time_step), 0.0)
         building._charging_constraint_penalty_kwh = penalty_kwh
         building._charging_constraint_last_penalty_kwh = penalty_kwh
         building._record_charging_constraint_state(

--- a/citylearn/internal/building_ops.py
+++ b/citylearn/internal/building_ops.py
@@ -772,7 +772,7 @@ class BuildingOpsService:
                     'phase_power_kw': {},
                 }
 
-            penalty_kwh = self._safe_scalar(violation_kw * (building.hours_per_time_step), 0.0)
+            penalty_kwh = self._safe_scalar(violation_kw * building.hours_per_time_step, 0.0)
             building._charging_constraint_penalty_kwh = penalty_kwh
             building._charging_constraint_last_penalty_kwh = penalty_kwh
             phase_power = {}
@@ -929,7 +929,7 @@ class BuildingOpsService:
             'phase_power_kw': phase_kw,
         }
 
-        penalty_kwh = self._safe_scalar(violation_kw * (building.hours_per_time_step), 0.0)
+        penalty_kwh = self._safe_scalar(violation_kw * building.hours_per_time_step, 0.0)
         building._charging_constraint_penalty_kwh = penalty_kwh
         building._charging_constraint_last_penalty_kwh = penalty_kwh
         building._record_charging_constraint_state(

--- a/tests/unit/test_subhour_scaling.py
+++ b/tests/unit/test_subhour_scaling.py
@@ -110,8 +110,7 @@ def test_storage_charge_scaling_respects_time_ratio():
     storage.reset()
 
     energy_actual = 2.5  # kWh to add over a 15-minute step at full power
-    dataset_energy = energy_actual / storage.time_step_ratio
-    storage.charge(dataset_energy)
+    storage.charge(energy_actual)
 
     assert storage.energy_balance[0] == pytest.approx(energy_actual)
 
@@ -156,7 +155,7 @@ def test_battery_electricity_consumption_tracks_energy_balance_in_subhour():
     battery.reset()
 
     # Dataset-resolution command corresponding to 2.5 kWh over a 15-minute step.
-    battery.charge(10.0)
+    battery.charge(2.5)
 
     assert battery.energy_balance[0] == pytest.approx(2.5)
     assert battery.electricity_consumption[0] == pytest.approx(2.5)

--- a/tests/unit/test_subhourly_storage_scaling.py
+++ b/tests/unit/test_subhourly_storage_scaling.py
@@ -1,0 +1,102 @@
+"""Tests verifying that storage behaviour does not depend on the length of a time step."""
+
+import pytest
+
+pytest.importorskip("gymnasium")
+
+from citylearn.base import EpisodeTracker
+from citylearn.energy_model import Battery, StorageDevice, StorageTank
+
+FLAT_CURVE = [[0.0, 1.0], [1.0, 1.0]]
+HALF_RATING_CURVE = [[0.0, 0.5], [1.0, 0.5]]
+QUARTER_HOUR = 900
+
+
+def _make_tracker(length: int) -> EpisodeTracker:
+    tracker = EpisodeTracker(0, length - 1)
+    tracker.next_episode(length, rolling_episode_split=False, random_episode_split=False, random_seed=0)
+
+    return tracker
+
+
+def _make_battery(capacity_power_curve=None, power_efficiency_curve=None) -> Battery:
+    battery = Battery(
+        capacity=1000.0,
+        nominal_power=50.0,
+        initial_soc=0.0,
+        efficiency=1.0,
+        loss_coefficient=0.0,
+        capacity_loss_coefficient=0.0,
+        depth_of_discharge=1.0,
+        power_efficiency_curve=FLAT_CURVE if power_efficiency_curve is None else power_efficiency_curve,
+        capacity_power_curve=FLAT_CURVE if capacity_power_curve is None else capacity_power_curve,
+        seconds_per_time_step=QUARTER_HOUR,
+        episode_tracker=_make_tracker(8),
+    )
+    battery.reset()
+
+    return battery
+
+
+def test_standby_loss_is_deducted_per_hour_not_per_step():
+    storage = StorageDevice(
+        capacity=100.0,
+        efficiency=1.0,
+        loss_coefficient=0.01,
+        initial_soc=1.0,
+        seconds_per_time_step=QUARTER_HOUR,
+        episode_tracker=_make_tracker(8),
+    )
+    storage.reset()
+
+    for _ in range(4):
+        storage.charge(0.0)
+        storage.next_time_step()
+
+    # An hour of standing still costs the same charge however finely it is sliced. Deducting
+    # the hourly loss on every step instead leaves 0.99**4 = 0.9606.
+    assert storage.soc[3] == pytest.approx(0.99)
+
+
+def test_efficiency_curve_is_read_at_the_fraction_of_rated_power():
+    battery = _make_battery(power_efficiency_curve=[[0.0, 0.5], [1.0, 1.0]])
+    battery.charge(50.0*0.25)  # the full 50 kW rating, for a quarter of an hour
+
+    # power_efficiency_curve is indexed by fraction of rated power, so this is a fraction of
+    # 1.0. Dividing the step's kWh by a kW rating reads the curve at 0.25 and gives 0.625.
+    assert battery.efficiency == pytest.approx(1.0)
+
+
+def test_capacity_power_curve_limits_power_not_step_energy():
+    battery = _make_battery(capacity_power_curve=HALF_RATING_CURVE)
+    battery.charge(100.0)
+
+    # The taper caps a rate in kW, so a quarter-hour step may take a quarter of it. Comparing
+    # that limit against kWh directly lets 25.0 kWh through.
+    assert battery.energy_balance[0] == pytest.approx(50.0*0.5*0.25)
+
+
+def test_nominal_power_limits_power_not_step_energy():
+    battery = _make_battery()
+    battery.charge(100.0)
+
+    # Likewise for nominal_power. Treating the rating as an energy allowance lets 50.0 kWh
+    # through in a quarter of an hour.
+    assert battery.energy_balance[0] == pytest.approx(50.0*0.25)
+
+
+def test_storage_tank_max_input_power_limits_power():
+    tank = StorageTank(
+        capacity=100.0,
+        efficiency=1.0,
+        loss_coefficient=0.0,
+        initial_soc=0.0,
+        max_input_power=10.0,
+        seconds_per_time_step=QUARTER_HOUR,
+        episode_tracker=_make_tracker(8),
+    )
+    tank.reset()
+    tank.charge(100.0)
+
+    # max_input_power is in kW too, and was being applied to the step's energy.
+    assert tank.energy_balance[0] == pytest.approx(10.0*0.25)


### PR DESCRIPTION
## Description

Battery charging and discharging does not behave in the same way when simulating the same case at
different granularities. This fixes the three differences reported in #163, all of which appear
when `seconds_per_time_step` is set to a lower granularity than 60 minutes and the dataset has the
same granularity as `seconds_per_time_step`.

As described in the issue, the `time_step_ratio` attribute is used in many places of the battery
energy model to account for smaller granularity time-steps. That works when the dataset is hourly
and `seconds_per_time_step` is set to a lower granularity, but not when the granularity of the
dataset is lower than 1 hour and `seconds_per_time_step` also. In that case
`seconds_per_time_step` and `base_step_seconds` are equal and the ratio is 1.0, while the
time-step is still shorter than an hour.

The fix follows the solution proposed in the issue: add an attribute `hours_per_time_step` to the
`Environment` class and apply it where `time_step_ratio` was wrongly applied.
## Issue

Fixes #163

## Changes

Line numbers are the ones on this branch, except where a line was deleted, which is marked and
points at the `master` line.

**`citylearn/base.py`**

- `base.py:215-219`: add the `hours_per_time_step` attribute to `Environment`, so buildings,
  devices, chargers and EV batteries all inherit the same definition of how long a time-step is in
  hours.

**`citylearn/energy_model.py`**

1. *The loss coefficient being applied at every time-step with the same intensity when  `time_step_ratio` was 1.0  regardless of the granularity of the simulation.*
   - `energy_model.py:690-694`: `StorageDevice.energy_init` now applies the loss over the duration
     of the time-step, `1 - (1 - loss_coefficient)**hours_per_time_step`, instead of applying the
     full hourly loss on every time-step.
     - Where the exponent comes from: `loss_coefficient` is defined per hour, so a fraction
     `1 - loss_coefficient` of the charge is left after one hour. An hour contains `n` time-steps,
     `n` being 4 for a 15-minute step. Calling `x` the fraction left after
     one step, those `n` steps have to leave the hourly amount between them, so
     `x**n = 1 - loss_coefficient` and `x = (1 - loss_coefficient)**(1/n)`. Since a step lasts
     `1/n` of an hour, `1/n` is exactly `hours_per_time_step`. At 0.01/h `loss_coefficient`, a 15-minute
     step leaves `0.99**0.25 = 0.99749` and so loses 0.00251 which is `1 - (1 - loss_coefficient)**hours_per_time_step`, and its four steps leave `0.99`.
   - `energy_model.py:673`: `StorageDevice.loss_coefficient` returns the configured hourly value
     instead the value scaled by `time_step_ratio` which was not an accurate way of scaling the
     loss_coefficient. It is scaled correctly in `energy_init` now.

2. *For non constant efficiency curves, the technical charging efficiency is different at
   different granularities for the same charging power.*
   - `energy_model.py:1131-1132`: In `Battery.get_current_efficiency`, `energy_normalized` is used as argument to get the charging efficiency from the power efficiency curve function. `energy_normalized` was calculated by doing `energy/nominal_power` which gave a wrong rating for smaller granularities than one hour. It is now replaced by `energy/(nominal_power*hours_per_time_step)` instead.

3. *The charging power is not capped correctly by the capacity power curve for granularities lower
   than 1 hour.*
   - `energy_model.py:1067-1070` and `energy_model.py:1077-1079`: `Battery.charge` converts
     `max_input_power`, `available_nominal_power ` and `max_output_power` to `max_input_energy`, `available_nominal_energy ` and `max_output_energy`  to consistently compare energy with energy (and not power). This is not an issue at 1 hour granularity becomes one for other granularities.
   - `energy_model.py:890-895`: `StorageTank.charge` does the same for `max_input_power` and
     `max_output_power`.
   - Deleted `master energy_model.py:758` and `master energy_model.py:889`:
     `StorageDevice.charge` and `StorageTank.charge` no longer multiply the incoming energy by
     `time_step_ratio`. This avoids confusion since before this for smaller granularities, the power must have been passed as the argument called `energy` to the charge function which is very confusing. This can be seen in `master test_subhour_scaling.py:114` and `master test_subhour_scaling.py:159` where the `energy` given to the charge function is actually the charging power and is called in the first case `dataset_energy`.

**`citylearn/building.py`**

- Remove `_convert_energy_for_storage`, deleted at `master building.py:1611-1620`, and its four call
  sites, now `building.py:1481` (cooling), `building.py:1530` (heating), `building.py:1575` (DHW)
  and `building.py:1608` (electrical storage). It divided by the ratio that
  `StorageDevice`/`StorageTank` multiplied back. This is not needed anymore since the charging energy is directly given to the charge function as `energy`.
The now-unused `StorageDevice` import is dropped at
  `building.py:14`.
- `building.py:121`, `building.py:1602`, `building.py:1693` and `building.py:1950`: use
  `hours_per_time_step` instead of computing `seconds_per_time_step / 3600` by hand.

**`citylearn/internal/building_ops.py`**

- `building_ops.py:775` and `building_ops.py:932`: same substitution as previous point in the two charging constraint
  penalty computations.

**`citylearn/electric_vehicle_charger.py`**

- `electric_vehicle_charger.py:343`: `Charger.charge` passes `battery_energy_kwh` straight to
  `battery.charge()` since this is the new behaviour of charge. Calculating the `battery_command` using `time_step_ratio` is not necessary anymore.

**`tests/unit/test_subhourly_storage_scaling.py`** (new)

- Five tests pinning each converted quantity to the duration of a time-step, at
  `test_subhourly_storage_scaling.py:41`, `:61`, `:70`, `:79` and `:88`. All five fail on versions 2.6.0b2
  with wrong values, and all five pass here.

**`tests/unit/test_subhour_scaling.py`**

- `test_subhour_scaling.py:158`: `test_battery_electricity_consumption_tracks_energy_balance_in_subhour`
  asserted the old behaviour, where `battery.charge(10.0)` was expected to store 2.5 kWh over a
  15-minute time-step. A command in kWh is now taken at face value, so the call becomes
  `battery.charge(2.5)`.
- `test_subhour_scaling.py:113`: `test_storage_charge_scaling_respects_time_ratio` charges
  `energy_actual` directly for the same reason, instead of pre-dividing it by `time_step_ratio`.

## Screenshots

The same three simulations as in #163, run again with this branch. Here are the before and after behaviours for the 3 issues:
1) Before:

<img width="1125" height="900" alt="1_standby_loss" src="https://github.com/user-attachments/assets/4bd42709-dc39-47ab-ad39-c243af123cef" />

After:

<img width="1125" height="900" alt="1_standby_loss" src="https://github.com/user-attachments/assets/e1505881-2762-42b5-ab40-6841be9b8315" />

2) Before:

<img width="1725" height="825" alt="2_efficiency_curve" src="https://github.com/user-attachments/assets/0eefd061-92e4-420b-8cb6-a5b41538e6ff" />

After:

<img width="1725" height="825" alt="2_efficiency_curve" src="https://github.com/user-attachments/assets/bfd94a65-2e8f-46f8-aaf0-1359e05364b4" />

3) Before:

<img width="1725" height="825" alt="3_charge_taper" src="https://github.com/user-attachments/assets/36990d23-326d-4443-81e7-eb691c8888ee" />

After:

<img width="1725" height="825" alt="3_charge_taper" src="https://github.com/user-attachments/assets/4619203a-8c91-4f00-b0bb-d97b3bfac712" />

Standby losses and charging efficiency become identical. The charging power converges but does
not match exactly, which is an ordinary discretisation error. This can be fixed but I decided to leave it out of this pull request.

## Checklist

- [x] I have tested the changes locally and they work as intended.
- [x] I have updated the documentation, if applicable.
- [x] I have added new tests, if applicable.
- [x] I have added any required dependencies to the `requirements.txt` file, if applicable.
- [x] I have followed the project's code style and conventions.

`pytest tests` passes the 194 tests, on Python 3.10. This includes the 5 additional tests from `tests/unit/test_subhourly_storage_scaling.py` and the two modified tests in `tests/unit/test_subhour_scaling.py`. 

## Additional notes

**Not covered here, happy to open follow-up issues:**

- From my current understanding, the same kind of errors exists in the `autosize` functions of `ElectricHeater`, `HeatPump`, `StorageDevice` and `Battery` where an energy demand is multiplied by `time_step_ratio` to define the nominal_power or capacity. This will give wrong results at smaller granularities. 
- The `update_electricity_consumption` of `ElectricDevice` that is used in the `Battery.charge` function still takes as argument an `electric_consumption` that is scaled by `time_step_ratio`. It would be more clear if it is defined as either energy or power to avoid similar errors as seen here.
